### PR TITLE
Separation from fetch and flatMap methods

### DIFF
--- a/Sources/ContentfulPersistence/CoreDataStore.swift
+++ b/Sources/ContentfulPersistence/CoreDataStore.swift
@@ -90,7 +90,8 @@ public class CoreDataStore: PersistenceStore {
      */
     public func fetchAll<T>(type: Any.Type, predicate: NSPredicate) throws -> [T] {
         let request = try fetchRequest(for: type, predicate: predicate)
-        return try context.fetch(request).flatMap { $0 as? T }
+        let items: [T] = try context.fetch(request) as! [T]
+        return items.flatMap { $0 as? T }
     }
 
     /**


### PR DESCRIPTION
The current implementation of fetchAll method it was allocationg too much memory causing heap corruption, from now the fethAll method has been improved to not allocate that amount of memory.

This PR is related to issue #52  