### PR TITLE
Add hint about array-based field deserialization to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ class Post: NSManagedObject, EntryPersistable {
 }
 ```
 
+**HINT:** For **array-based field types** (like `Short text, list`), use the type `Binary Data` in the data model, and the type `Data?` (e.g. `var tags: Data?`) in the Swift code. To access the actual array contents, unpack the `Data` field with `NSKeyedUnarchiver`, e.g.:
+
+```swift
+extension Post {
+
+    var theTags: [String]? {
+        guard let tagsData = self.tags else { return nil }
+        return NSKeyedUnarchiver.unarchiveObject(with: tagsData) as? [String]
+    }
+}
+```
+
 ## Installation
 
 ### CocoaPods installation


### PR DESCRIPTION
In order to give users more clarity about how to deserialize field types like
"Short text, list", a hint and some sample code is added to README.md.