### PR TITLE
Defer saving to persistence store until sync is completed

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "contentful/contentful.swift" ~> 5.0.0
+github "contentful/contentful.swift" ~> 5.0.2
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "AliSoftware/OHHTTPStubs" "8.0.0"
-github "contentful/contentful.swift" "5.0.0"
+github "contentful/contentful.swift" "5.0.2"

--- a/ContentfulPersistence.xcodeproj/project.pbxproj
+++ b/ContentfulPersistence.xcodeproj/project.pbxproj
@@ -33,6 +33,18 @@
 		5DD19BAC219F13730041F483 /* deleted-entry-initial.json in Resources */ = {isa = PBXBuildFile; fileRef = 5DD19BAB219F13730041F483 /* deleted-entry-initial.json */; };
 		5DD19BAD219F13730041F483 /* deleted-entry-initial.json in Resources */ = {isa = PBXBuildFile; fileRef = 5DD19BAB219F13730041F483 /* deleted-entry-initial.json */; };
 		5DD19BAE219F13730041F483 /* deleted-entry-initial.json in Resources */ = {isa = PBXBuildFile; fileRef = 5DD19BAB219F13730041F483 /* deleted-entry-initial.json */; };
+		6FCA36BB22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCA36BA22C65731004F9A5E /* RecordWithNonOptionalRelation.swift */; };
+		6FCA36BC22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCA36BA22C65731004F9A5E /* RecordWithNonOptionalRelation.swift */; };
+		6FCA36BD22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCA36BA22C65731004F9A5E /* RecordWithNonOptionalRelation.swift */; };
+		6FCA36BF22C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCA36BE22C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift */; };
+		6FCA36C022C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCA36BE22C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift */; };
+		6FCA36C122C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCA36BE22C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift */; };
+		6FD0311522CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FD0311422CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json */; };
+		6FD0311622CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FD0311422CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json */; };
+		6FD0311722CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FD0311422CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json */; };
+		6FD0311922CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FD0311822CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json */; };
+		6FD0311A22CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FD0311822CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json */; };
+		6FD0311B22CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FD0311822CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json */; };
 		ED10E88B1E48AB840061741F /* SynchronizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED10E8841E48AB840061741F /* SynchronizationManager.swift */; };
 		ED10E88C1E48AB840061741F /* CoreDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED10E8851E48AB840061741F /* CoreDataStore.swift */; };
 		ED10E88D1E48AB840061741F /* DataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED10E8861E48AB840061741F /* DataCache.swift */; };
@@ -244,6 +256,10 @@
 		5DA9AE0821A2B6AF0033BC4E /* deleted-asset-next.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "deleted-asset-next.json"; sourceTree = "<group>"; };
 		5DD19BA6219F0C940041F483 /* deleted-entry-next.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "deleted-entry-next.json"; sourceTree = "<group>"; };
 		5DD19BAB219F13730041F483 /* deleted-entry-initial.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "deleted-entry-initial.json"; sourceTree = "<group>"; };
+		6FCA36BA22C65731004F9A5E /* RecordWithNonOptionalRelation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordWithNonOptionalRelation.swift; sourceTree = "<group>"; };
+		6FCA36BE22C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecordWithNonOptionalRelation+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		6FD0311422CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "multi-page-non-optional-link-resolution1.json"; sourceTree = "<group>"; };
+		6FD0311822CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "multi-page-non-optional-link-resolution2.json"; sourceTree = "<group>"; };
 		A1A9FBE31CABE8EA00430734 /* ContentfulPersistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ContentfulPersistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1A9FBED1CABE8EA00430734 /* ContentfulPersistenceTests_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContentfulPersistenceTests_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED10E8841E48AB840061741F /* SynchronizationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SynchronizationManager.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -473,6 +489,8 @@
 				ED25D7EB1F17709A00A6BA9A /* ComplexSyncInfo+CoreDataProperties.swift */,
 				ED25D7E11F176D5900A6BA9A /* Link.swift */,
 				ED25D7E31F176D8E00A6BA9A /* Link+CoreDataProperties.swift */,
+				6FCA36BA22C65731004F9A5E /* RecordWithNonOptionalRelation.swift */,
+				6FCA36BE22C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift */,
 			);
 			path = ComplexTestModels;
 			sourceTree = "<group>";
@@ -500,6 +518,8 @@
 				ED25D7F91F1790B200A6BA9A /* simple-update-initial-sync.json */,
 				ED91F98F1F17A74D00540DAC /* simple-update-initial-sync-page2.json */,
 				ED91F9921F17A8C900540DAC /* simple-update-next-sync.json */,
+				6FD0311422CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json */,
+				6FD0311822CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json */,
 			);
 			path = ComplexTestStubs;
 			sourceTree = "<group>";
@@ -836,6 +856,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = A1A9FBD91CABE8EA00430734;
@@ -872,6 +893,7 @@
 				EDBDBFD81F28B6E800649F5A /* localization-sync.json in Resources */,
 				ED4023EA20EA5A15001C6BDD /* unresolvable-links.json in Resources */,
 				5D001E5E2004019D00AC5A4C /* symbols-array.json in Resources */,
+				6FD0311522CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json in Resources */,
 				5DA9AE0C21A2B6AF0033BC4E /* deleted-asset-next.json in Resources */,
 				ED91F99E1F18C79D00540DAC /* multi-page-link-resolution1.json in Resources */,
 				EDCFBF9D1F161EB6002B1B73 /* single-author.json in Resources */,
@@ -884,6 +906,7 @@
 				ED1BA7D01F16288100E21FD5 /* space.json in Resources */,
 				ED8C1E881F6175A5001D059F /* MultifilePreseedJSONFiles in Resources */,
 				ED91F99F1F18C79D00540DAC /* multi-page-link-resolution2.json in Resources */,
+				6FD0311922CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */,
 				ED79E9281FCC23E10045F44F /* MultilocalePreseedJSONFiles in Resources */,
 				EDE5BA39207220F900A650FE /* video-asset.json in Resources */,
 				ED6B67A21F1CB350008EC7C8 /* nullified-link-initial.json in Resources */,
@@ -927,6 +950,7 @@
 				EDD8F4F01F5401FD0000D3BB /* clear-field-next-sync.json in Resources */,
 				ED4023EB20EA5A15001C6BDD /* unresolvable-links.json in Resources */,
 				5D001E5D2004019D00AC5A4C /* symbols-array.json in Resources */,
+				6FD0311622CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json in Resources */,
 				5DA9AE0D21A2B6AF0033BC4E /* deleted-asset-next.json in Resources */,
 				EDD8F52B1F5402290000D3BB /* single-author.json in Resources */,
 				EDD8F4F51F5401FD0000D3BB /* simple-update-initial-sync.json in Resources */,
@@ -939,6 +963,7 @@
 				EDD8F4EF1F5401FD0000D3BB /* clear-field-initial-sync.json in Resources */,
 				ED8C1E891F6175A5001D059F /* MultifilePreseedJSONFiles in Resources */,
 				EDD8F4ED1F5401F50000D3BB /* localization-sync.json in Resources */,
+				6FD0311A22CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */,
 				ED79E9291FCC23E10045F44F /* MultilocalePreseedJSONFiles in Resources */,
 				EDE5BA3A207220FA00A650FE /* video-asset.json in Resources */,
 				EDD8F4F71F5401FD0000D3BB /* simple-update-next-sync.json in Resources */,
@@ -961,6 +986,7 @@
 				EDD8F4F91F5401FD0000D3BB /* clear-field-next-sync.json in Resources */,
 				ED4023EC20EA5A15001C6BDD /* unresolvable-links.json in Resources */,
 				5D001E5C2004019C00AC5A4C /* symbols-array.json in Resources */,
+				6FD0311722CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json in Resources */,
 				5DA9AE0E21A2B6AF0033BC4E /* deleted-asset-next.json in Resources */,
 				EDD8F52E1F5402290000D3BB /* single-author.json in Resources */,
 				EDD8F4FE1F5401FD0000D3BB /* simple-update-initial-sync.json in Resources */,
@@ -973,6 +999,7 @@
 				EDD8F4F81F5401FD0000D3BB /* clear-field-initial-sync.json in Resources */,
 				ED8C1E8A1F6175A5001D059F /* MultifilePreseedJSONFiles in Resources */,
 				EDD8F4EE1F5401F60000D3BB /* localization-sync.json in Resources */,
+				6FD0311B22CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */,
 				ED79E92A1FCC23E10045F44F /* MultilocalePreseedJSONFiles in Resources */,
 				EDE5BA3B207220FA00A650FE /* video-asset.json in Resources */,
 				EDD8F5001F5401FD0000D3BB /* simple-update-next-sync.json in Resources */,
@@ -1068,6 +1095,7 @@
 				ED10E8B71E48ACBD0061741F /* Asset.swift in Sources */,
 				ED10E8BA1E48ACBD0061741F /* Author+CoreDataProperties.swift in Sources */,
 				ED10E8BE1E48ACBD0061741F /* Post+CoreDataProperties.swift in Sources */,
+				6FCA36BB22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */,
 				ED25D7D81F16654A00A6BA9A /* ComplexSyncTests.swift in Sources */,
 				ED10E8B91E48ACBD0061741F /* Author.swift in Sources */,
 				ED10E8BD1E48ACBD0061741F /* Post.swift in Sources */,
@@ -1079,6 +1107,7 @@
 				ED25D7E01F166C1700A6BA9A /* SingleRecord+CoreDataProperties.swift in Sources */,
 				ED10E8BB1E48ACBD0061741F /* Category.swift in Sources */,
 				EDBDBFD21F28B1EB00649F5A /* LocalizationTests.swift in Sources */,
+				6FCA36BF22C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift in Sources */,
 				ED25D7EC1F17709A00A6BA9A /* ComplexSyncInfo+CoreDataProperties.swift in Sources */,
 				EDCFBFA01F162449002B1B73 /* Test.xcdatamodeld in Sources */,
 				EDBDBFD51F28B23B00649F5A /* LocalizationTest.xcdatamodeld in Sources */,
@@ -1141,6 +1170,7 @@
 				EDD8F51B1F5402200000D3BB /* Post.swift in Sources */,
 				EDD8F4EB1F5401EF0000D3BB /* TestHelpers.swift in Sources */,
 				EDD8F4E51F5401E50000D3BB /* SynchronizationManagerTests.swift in Sources */,
+				6FCA36BC22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */,
 				EDD8F5071F5402040000D3BB /* Link.swift in Sources */,
 				EDD8F5021F5402040000D3BB /* SingleRecord+CoreDataProperties.swift in Sources */,
 				EDD8F5161F5402200000D3BB /* Asset+CoreDataProperties.swift in Sources */,
@@ -1152,6 +1182,7 @@
 				EDD8F5041F5402040000D3BB /* ComplexAsset+CoreDataProperties.swift in Sources */,
 				EDD8F51E1F5402200000D3BB /* SyncInfo+CoreDataProperties.swift in Sources */,
 				EDD8F5191F5402200000D3BB /* Category.swift in Sources */,
+				6FCA36C022C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift in Sources */,
 				EDD8F5031F5402040000D3BB /* ComplexAsset.swift in Sources */,
 				EDD8F5171F5402200000D3BB /* Author.swift in Sources */,
 				EDD8F5181F5402200000D3BB /* Author+CoreDataProperties.swift in Sources */,
@@ -1175,6 +1206,7 @@
 				EDD8F5251F5402200000D3BB /* Post.swift in Sources */,
 				EDD8F4EC1F5401EF0000D3BB /* TestHelpers.swift in Sources */,
 				EDD8F4E61F5401E50000D3BB /* SynchronizationManagerTests.swift in Sources */,
+				6FCA36BD22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */,
 				EDD8F50F1F5402040000D3BB /* Link.swift in Sources */,
 				EDD8F50A1F5402040000D3BB /* SingleRecord+CoreDataProperties.swift in Sources */,
 				EDD8F5201F5402200000D3BB /* Asset+CoreDataProperties.swift in Sources */,
@@ -1186,6 +1218,7 @@
 				EDD8F50D1F5402040000D3BB /* ComplexSyncInfo.swift in Sources */,
 				EDD8F50C1F5402040000D3BB /* ComplexAsset+CoreDataProperties.swift in Sources */,
 				EDD8F5281F5402200000D3BB /* SyncInfo+CoreDataProperties.swift in Sources */,
+				6FCA36C122C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift in Sources */,
 				EDD8F5231F5402200000D3BB /* Category.swift in Sources */,
 				EDD8F50B1F5402040000D3BB /* ComplexAsset.swift in Sources */,
 				EDD8F5211F5402200000D3BB /* Author.swift in Sources */,

--- a/ContentfulPersistence.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ContentfulPersistence.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/ContentfulPersistence/SynchronizationManager.swift
+++ b/Sources/ContentfulPersistence/SynchronizationManager.swift
@@ -171,7 +171,15 @@ public class SynchronizationManager: PersistenceIntegration {
 
             self?.resolveRelationships()
             self?.update(syncToken: syncSpace.syncToken)
-            self?.save()
+
+            // Only save updates to the persistence store if the sync is completed
+            // (has no more pages). Else, non-optional relations whose nodes
+            // are sent in different pages would fail to be stored. This is the
+            // case because e.g. CoreData validates non-optional relations when
+            // save() is called.
+            if syncSpace.hasMorePages == false {
+                self?.save()
+            }
         }
     }
 

--- a/Tests/ContentfulPersistenceTests/ComplexSyncTests.swift
+++ b/Tests/ContentfulPersistenceTests/ComplexSyncTests.swift
@@ -80,6 +80,7 @@ class ComplexSyncTests: XCTestCase {
                         let records: [SingleRecord] = try self.store.fetchAll(type: SingleRecord.self,  predicate: NSPredicate(format: "id == 'aNt2d7YR4AIwEAMcG4OwI'"))
                         XCTAssertEqual(records.count, 1)
                         if let helloRecord = records.first {
+                            XCTAssertFalse(helloRecord.hasChanges, "Record has not yet been saved")
                             XCTAssertEqual(helloRecord.textBody, "Hello")
                         }
                     } catch {
@@ -114,6 +115,7 @@ class ComplexSyncTests: XCTestCase {
                     do {
                         let helloSingleRecord: [SingleRecord] = try self.store.fetchAll(type: SingleRecord.self,  predicate: NSPredicate(format: "id == 'aNt2d7YR4AIwEAMcG4OwI'"))
                         XCTAssertEqual(helloSingleRecord.count, 1)
+                        XCTAssertFalse(helloSingleRecord.first!.hasChanges, "Record has not yet been saved")
                         XCTAssertEqual(helloSingleRecord.first!.textBody, "Hello FooBar")
                     } catch {
                         XCTAssert(false, "Fetching posts should not throw an error")
@@ -148,6 +150,7 @@ class ComplexSyncTests: XCTestCase {
                         let records: [SingleRecord] = try self.store.fetchAll(type: SingleRecord.self,  predicate: NSPredicate(format: "id == '5GiLOZvY7SiMeUIgIIAssS'"))
                         XCTAssertEqual(records.count, 1)
                         if let record = records.first {
+                            XCTAssertFalse(record.hasChanges, "Record has not yet been saved")
                             XCTAssertEqual(record.textBody, "INITIAL TEXT BODY")
                         }
                     } catch {
@@ -181,6 +184,7 @@ class ComplexSyncTests: XCTestCase {
                     do {
                         let blankTextBodyRecord: [SingleRecord] = try self.store.fetchAll(type: SingleRecord.self,  predicate: NSPredicate(format: "id == '5GiLOZvY7SiMeUIgIIAssS'"))
                         XCTAssertEqual(blankTextBodyRecord.count, 1)
+                        XCTAssertFalse(blankTextBodyRecord.first?.hasChanges ?? false, "Record has not yet been saved")
                         XCTAssertNil(blankTextBodyRecord.first!.textBody)
                     } catch {
                         XCTAssert(false, "Fetching posts should not throw an error")
@@ -224,6 +228,7 @@ class ComplexSyncTests: XCTestCase {
                         let records: [SingleRecord] = try self.store.fetchAll(type: SingleRecord.self,  predicate: NSPredicate(format: "id == '14XouHzspI44uKCcMicWUY'"))
                         XCTAssertEqual(records.count, 1)
                         if let record = records.first {
+                            XCTAssertFalse(record.hasChanges, "Record has not yet been saved")
                             XCTAssertNotNil(record.linkField)
                             if let linkedField = record.linkField {
                                 XCTAssertEqual(linkedField.awesomeLinkTitle, "AWESOMELINK!!!")
@@ -263,6 +268,7 @@ class ComplexSyncTests: XCTestCase {
                         let records: [SingleRecord] = try self.store.fetchAll(type: SingleRecord.self,  predicate: NSPredicate(format: "id == '5GiLOZvY7SiMeUIgIIAssS'"))
                         XCTAssertEqual(records.count, 1)
                         if let record = records.first {
+                            XCTAssertFalse(record.hasChanges, "Record has not yet been saved")
                             XCTAssertNotNil(record.linkField)
                             if let linkedField = record.linkField {
                                 XCTAssertEqual(linkedField.awesomeLinkTitle, "To be nullified")
@@ -334,6 +340,7 @@ class ComplexSyncTests: XCTestCase {
                         let records: [SingleRecord] = try self.store.fetchAll(type: SingleRecord.self,  predicate: NSPredicate(format: "id == 'aNt2d7YR4AIwEAMcG4OwI'"))
                         XCTAssertEqual(records.count, 1)
                         if let record = records.first {
+                            XCTAssertFalse(record.hasChanges, "Record has not yet been saved")
                             XCTAssertEqual(record.textBody, "Hello")
                         }
                     }
@@ -403,9 +410,11 @@ class ComplexSyncTests: XCTestCase {
                         let records: [SingleRecord] = try self.store.fetchAll(type: SingleRecord.self,  predicate: NSPredicate(value: true))
                         XCTAssertEqual(records.count, 2)
                         if let record = records.filter({ $0.localeCode == "en-US" }).first {
+                            XCTAssertFalse(record.hasChanges, "Record has not yet been saved")
                             XCTAssertEqual(record.textBody, "Hello")
                         }
                         if let record = records.filter({ $0.localeCode == "es-MX" }).first {
+                            XCTAssertFalse(record.hasChanges, "Record has not yet been saved")
                             XCTAssertEqual(record.textBody, "Hola")
                         }
                     }
@@ -475,6 +484,7 @@ class ComplexSyncTests: XCTestCase {
                         let assets: [ComplexAsset] = try self.store.fetchAll(type: ComplexAsset.self,  predicate: NSPredicate(format: "id == 'YokO2rWbOoo68QmiEUkqe'"))
                         XCTAssertEqual(assets.count, 1)
                         if let asset = assets.first {
+                            XCTAssertFalse(asset.hasChanges, "Asset has not yet been saved")
                             XCTAssertEqual(asset.title, "Video asset")
                         }
                     }
@@ -540,6 +550,7 @@ class ComplexSyncTests: XCTestCase {
                         let records: [SingleRecord] = try self.store.fetchAll(type: SingleRecord.self,  predicate: NSPredicate(format: "id == '4VTL2TY7rikiS6c2MI2is4'"))
                         XCTAssertEqual(records.count, 1)
                         if let record = records.first {
+                            XCTAssertFalse(record.hasChanges, "Record has not yet been saved")
                             XCTAssertNotNil(record.locationField)
                             if let locationField = record.locationField {
                                 XCTAssertEqual(locationField.latitude, 34.4208305)
@@ -582,6 +593,7 @@ class ComplexSyncTests: XCTestCase {
                         let assets: [ComplexAsset] = try self.store.fetchAll(type: ComplexAsset.self,  predicate: NSPredicate(format: "id == 'YokO2rWbOoo68QmiEUkqe'"))
                         XCTAssertEqual(assets.count, 1)
                         if let asset = assets.first {
+                            XCTAssertFalse(asset.hasChanges, "Asset has not yet been saved")
                             XCTAssertNotNil(asset.urlString)
                             XCTAssertEqual(asset.urlString ,"https://videos.ctfassets.net/r3rkxrglg2d1/YokO2rWbOoo68QmiEUkqe/5cd5ab8fc90e7b9b4d99d56ea29de768/JP_Swift_Demo.mp4")
                         } else {
@@ -620,6 +632,7 @@ class ComplexSyncTests: XCTestCase {
                 XCTAssertEqual(records.count, 1)
 
                 if let linkedAsset = records.first?.assetLinkField {
+                    XCTAssertFalse(linkedAsset.hasChanges, "Asset has not yet been saved")
                     XCTAssertEqual(linkedAsset.id, "6Wsz8owhtCGSICg44IUYAm")
                     XCTAssertEqual(linkedAsset.title, "First asset in array")
                 } else {
@@ -631,6 +644,7 @@ class ComplexSyncTests: XCTestCase {
                 XCTAssertEqual(secondRecordsSet.count, 1)
 
                 if let linkedAsset = secondRecordsSet.first?.assetLinkField {
+                    XCTAssertFalse(linkedAsset.hasChanges, "Asset has not yet been saved")
                     XCTAssertEqual(linkedAsset.id, "6Wsz8owhtCGSICg44IUYAm")
                     XCTAssertEqual(linkedAsset.title, "First asset in array")
                 } else {
@@ -661,6 +675,7 @@ class ComplexSyncTests: XCTestCase {
                 XCTAssertEqual(records.count, 1)
 
                 if let linkedAssetsSet = records.first?.assetsArrayLinkField {
+                    XCTAssertFalse(records.first!.hasChanges, "Record has not yet been saved")
                     XCTAssertEqual(linkedAssetsSet.count, 2)
                     XCTAssertEqual((linkedAssetsSet.firstObject as? ComplexAsset)?.title, "First asset in array")
                     XCTAssertEqual((linkedAssetsSet[1] as? ComplexAsset)?.title, "Second asset in array")
@@ -692,6 +707,7 @@ class ComplexSyncTests: XCTestCase {
                 XCTAssertEqual(records.count, 1)
 
                 if let linkedStringsData = records.first?.symbolsArray, let linkedStringsArray = NSKeyedUnarchiver.unarchiveObject(with: linkedStringsData) as? [String] {
+                    XCTAssertFalse(records.first!.hasChanges, "Record has not yet been saved")
                     XCTAssertEqual(linkedStringsArray.count, 5)
                     XCTAssertEqual(linkedStringsArray.first, "one")
                     XCTAssertEqual(linkedStringsArray.last, "five")
@@ -753,6 +769,8 @@ class ComplexSyncTests: XCTestCase {
                         XCTAssertEqual(records.count, 1)
                         if let record = records.first {
                             XCTAssertEqual(record.nonOptionalLink.awesomeLinkTitle, "Non-optional Link")
+                            XCTAssertFalse(record.hasChanges, "Link has not yet been saved")
+                            XCTAssertFalse(record.nonOptionalLink.hasChanges, "Link has not yet been saved")
                         }
                     } catch {
                         XCTFail("Fetching RecordWithNonOptionalRelation should not throw an error")

--- a/Tests/ContentfulPersistenceTests/ComplexTest.xcdatamodeld/ComplexTest.xcdatamodel/contents
+++ b/Tests/ContentfulPersistenceTests/ComplexTest.xcdatamodeld/ComplexTest.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="17G3025" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.99" systemVersion="18G48f" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ComplexAsset" representedClassName="ComplexAsset" syncable="YES">
         <attribute name="assetDescription" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -25,7 +25,15 @@
         <attribute name="id" attributeType="String" syncable="YES"/>
         <attribute name="localeCode" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="recordWithNonOptionalRelationInverse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RecordWithNonOptionalRelation" inverseName="nonOptionalLink" inverseEntity="RecordWithNonOptionalRelation" syncable="YES"/>
         <relationship name="singleRecordInverse" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SingleRecord" inverseName="linkField" inverseEntity="SingleRecord" syncable="YES"/>
+    </entity>
+    <entity name="RecordWithNonOptionalRelation" representedClassName="RecordWithNonOptionalRelation" syncable="YES">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="localeCode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="nonOptionalLink" maxCount="1" deletionRule="Nullify" destinationEntity="Link" inverseName="recordWithNonOptionalRelationInverse" inverseEntity="Link" syncable="YES"/>
     </entity>
     <entity name="SingleRecord" representedClassName="SingleRecord" syncable="YES">
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -43,7 +51,8 @@
     <elements>
         <element name="ComplexAsset" positionX="-63" positionY="-18" width="128" height="255"/>
         <element name="ComplexSyncInfo" positionX="-54" positionY="-9" width="128" height="60"/>
-        <element name="Link" positionX="-18" positionY="99" width="128" height="135"/>
+        <element name="Link" positionX="-18" positionY="99" width="128" height="150"/>
+        <element name="RecordWithNonOptionalRelation" positionX="-36" positionY="126" width="128" height="120"/>
         <element name="SingleRecord" positionX="-36" positionY="90" width="128" height="210"/>
     </elements>
 </model>

--- a/Tests/ContentfulPersistenceTests/ComplexTestModels/RecordWithNonOptionalRelation+CoreDataProperties.swift
+++ b/Tests/ContentfulPersistenceTests/ComplexTestModels/RecordWithNonOptionalRelation+CoreDataProperties.swift
@@ -1,0 +1,29 @@
+//
+//  RecordWithNonOptionalRelation+CoreDataProperties.swift
+//  ContentfulPersistence
+//
+//  Created by Manuel Maly on 28.06.19.
+//  Copyright © 2019 Contentful GmbH. All rights reserved.
+//
+
+import Foundation
+import CoreData
+import Contentful
+import ContentfulPersistence
+
+extension RecordWithNonOptionalRelation: EntryPersistable {
+
+    static let contentTypeId = "recordWithNonOptionalRelation"
+
+    @NSManaged var id: String
+    @NSManaged var localeCode: String?
+    @NSManaged var createdAt: Date?
+    @NSManaged var updatedAt: Date?
+    @NSManaged var nonOptionalLink: Link
+
+    static func fieldMapping() -> [FieldName: String] {
+        return [
+            "nonOptionalLink": "nonOptionalLink"
+        ]
+    }
+}

--- a/Tests/ContentfulPersistenceTests/ComplexTestModels/RecordWithNonOptionalRelation.swift
+++ b/Tests/ContentfulPersistenceTests/ComplexTestModels/RecordWithNonOptionalRelation.swift
@@ -1,0 +1,15 @@
+//
+//  RecordWithNonOptionalRelation.swift
+//  ContentfulPersistence
+//
+//  Created by Manuel Maly on 28.06.19.
+//  Copyright © 2019 Contentful GmbH. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+@objc(RecordWithNonOptionalRelation)
+class RecordWithNonOptionalRelation: NSManagedObject {
+    // Insert code here to add functionality to your managed object subclass
+}

--- a/Tests/ContentfulPersistenceTests/ComplexTestStubs/multi-page-non-optional-link-resolution1.json
+++ b/Tests/ContentfulPersistenceTests/ComplexTestStubs/multi-page-non-optional-link-resolution1.json
@@ -1,0 +1,45 @@
+{
+    "sys" : {
+        "type" : "Array"
+    },
+    "items" : [
+        {
+            "sys" : {
+                "space" : {
+                    "sys" : {
+                        "type" : "Link",
+                        "linkType" : "Space",
+                        "id" : "smf0sqiu0c5s"
+                    }
+                },
+                "id" : "15OmnIzspI44uKCcNzcPUS",
+                "type" : "Entry",
+                "createdAt" : "2017-06-20T14:03:29.046Z",
+                "updatedAt" : "2017-07-14T09:10:48.128Z",
+                "revision" : 3,
+                "contentType" : {
+                    "sys" : {
+                        "type" : "Link",
+                        "linkType" : "ContentType",
+                        "id" : "recordWithNonOptionalRelation"
+                    }
+                }
+            },
+            "fields" : {
+                "textBody" : {
+                    "en-US" : "Record With Link"
+                },
+                "nonOptionalLink" : {
+                    "en-US" : {
+                        "sys" : {
+                            "type" : "Link",
+                            "linkType" : "Entry",
+                            "id" : "3YYdCPjS0I6TNAFiCOEplO"
+                        }
+                    }
+                }
+            }
+        }
+    ],
+    "nextPageUrl" : "http://cdn.contentful.com/spaces/smf0sqiu0c5s/environments/master/sync?sync_token=multi-page-non-optional-link-resolution-token"
+}

--- a/Tests/ContentfulPersistenceTests/ComplexTestStubs/multi-page-non-optional-link-resolution2.json
+++ b/Tests/ContentfulPersistenceTests/ComplexTestStubs/multi-page-non-optional-link-resolution2.json
@@ -1,0 +1,37 @@
+{
+    "sys" : {
+        "type" : "Array"
+    },
+    "items" : [
+        {
+            "sys" : {
+                "space" : {
+                    "sys" : {
+                        "type" : "Link",
+                        "linkType" : "Space",
+                        "id" : "smf0sqiu0c5s"
+                    }
+                },
+                "id" : "3YYdCPjS0I6TNAFiCOEplO",
+                "type" : "Entry",
+                "createdAt" : "2017-06-20T14:03:29.046Z",
+                "updatedAt" : "2017-07-14T09:10:48.128Z",
+                "revision" : 3,
+                "contentType" : {
+                    "sys" : {
+                        "type" : "Link",
+                        "linkType" : "ContentType",
+                        "id" : "link"
+                    }
+                }
+            },
+            "fields" : {
+                "awesomeLinkTitle" : {
+                    "en-US" : "Non-optional Link"
+                }
+            }
+        }
+    ],
+    "nextSyncUrl" : "http://cdn.contentful.com/spaces/smf0sqiu0c5s/environments/master/sync?sync_token=multi-page-non-optional-link-resolution1.json"
+}
+


### PR DESCRIPTION
In `SynchronizationManager`, a call to `save()` in `update(with:)` entailed that non-optional relationships that were synced across multiple pages were not resolved when CoreData validated the relationship after processing each page, which resulted in an unrecoverable error. The solution proposed in this PR is to defer calling `save()` until the sync has no more pages to process. Thus, the relationship validation is performed only after the last page has been processed.

To ensure that the deferral of calling `save()` does not negatively affect other use cases, asserts have been added to most complex sync tests that ensure that the synced records have been written to storage (`hasChanges == false`).