### PR TITLE
Entries Relationship Caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10.2
+osx_image: xcode11.4
 rvm:
   - 2.4.3
 cache: bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) starting from 
 ## Table of contents
 
 #### 0.x Releases
+- `0.15.x` Releases - [0.15.3](#0153)
 - `0.13.x` Releases - [0.13.0](#0130)
 - `0.12.x` Releases - [0.12.0](#0120) | [0.12.1](#0121)
 - `0.11.x` Releases - [0.11.0](#0110)
@@ -20,6 +21,15 @@ This project adheres to [Semantic Versioning](http://semver.org/) starting from 
 - `0.6.x` Releases - [0.6.0](#060) | [0.6.1](#061) | [0.6.2](#062)
 - `0.5.x` Releases - [0.5.0](#050)
 - `0.4.x` Releases - [0.4.0](#040)
+
+---
+
+## [`0.15.3`](https://github.com/contentful/contentful-persistence.swift/releases/tag/0.15.3)
+Released on 2020-08-31
+
+#### Changed
+- Updated [contentful.swift](https://github.com/contentful/contentful.swift) dependency to 5.2.0.
+- Fixed updating relationships between entry and its parent when that entry has been unpublished and published between synchronization calls.
 
 ---
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "contentful/contentful.swift" ~> 5.1.0
+github "contentful/contentful.swift" ~> 5.2.0
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "AliSoftware/OHHTTPStubs" "9.0.0"
-github "contentful/contentful.swift" "5.1.0"
+github "contentful/contentful.swift" "5.2.0"

--- a/ContentfulPersistence.xcodeproj/project.pbxproj
+++ b/ContentfulPersistence.xcodeproj/project.pbxproj
@@ -33,6 +33,48 @@
 		5DD19BAC219F13730041F483 /* deleted-entry-initial.json in Resources */ = {isa = PBXBuildFile; fileRef = 5DD19BAB219F13730041F483 /* deleted-entry-initial.json */; };
 		5DD19BAD219F13730041F483 /* deleted-entry-initial.json in Resources */ = {isa = PBXBuildFile; fileRef = 5DD19BAB219F13730041F483 /* deleted-entry-initial.json */; };
 		5DD19BAE219F13730041F483 /* deleted-entry-initial.json in Resources */ = {isa = PBXBuildFile; fileRef = 5DD19BAB219F13730041F483 /* deleted-entry-initial.json */; };
+		6D5CEDB924FC2493005E8B41 /* ToManyRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB524FC2493005E8B41 /* ToManyRelationship.swift */; };
+		6D5CEDBA24FC2493005E8B41 /* ToManyRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB524FC2493005E8B41 /* ToManyRelationship.swift */; };
+		6D5CEDBB24FC2493005E8B41 /* ToManyRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB524FC2493005E8B41 /* ToManyRelationship.swift */; };
+		6D5CEDBC24FC2493005E8B41 /* ToManyRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB524FC2493005E8B41 /* ToManyRelationship.swift */; };
+		6D5CEDBD24FC2493005E8B41 /* RelationshipCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB624FC2493005E8B41 /* RelationshipCache.swift */; };
+		6D5CEDBE24FC2493005E8B41 /* RelationshipCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB624FC2493005E8B41 /* RelationshipCache.swift */; };
+		6D5CEDBF24FC2493005E8B41 /* RelationshipCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB624FC2493005E8B41 /* RelationshipCache.swift */; };
+		6D5CEDC024FC2493005E8B41 /* RelationshipCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB624FC2493005E8B41 /* RelationshipCache.swift */; };
+		6D5CEDC124FC2493005E8B41 /* Relationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB724FC2493005E8B41 /* Relationship.swift */; };
+		6D5CEDC224FC2493005E8B41 /* Relationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB724FC2493005E8B41 /* Relationship.swift */; };
+		6D5CEDC324FC2493005E8B41 /* Relationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB724FC2493005E8B41 /* Relationship.swift */; };
+		6D5CEDC424FC2493005E8B41 /* Relationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB724FC2493005E8B41 /* Relationship.swift */; };
+		6D5CEDC524FC2493005E8B41 /* ToOneRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB824FC2493005E8B41 /* ToOneRelationship.swift */; };
+		6D5CEDC624FC2493005E8B41 /* ToOneRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB824FC2493005E8B41 /* ToOneRelationship.swift */; };
+		6D5CEDC724FC2493005E8B41 /* ToOneRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB824FC2493005E8B41 /* ToOneRelationship.swift */; };
+		6D5CEDC824FC2493005E8B41 /* ToOneRelationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDB824FC2493005E8B41 /* ToOneRelationship.swift */; };
+		6D5CEDCA24FC24B1005E8B41 /* RelationshipsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDC924FC24B1005E8B41 /* RelationshipsManager.swift */; };
+		6D5CEDCB24FC24B1005E8B41 /* RelationshipsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDC924FC24B1005E8B41 /* RelationshipsManager.swift */; };
+		6D5CEDCC24FC24B1005E8B41 /* RelationshipsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDC924FC24B1005E8B41 /* RelationshipsManager.swift */; };
+		6D5CEDCD24FC24B1005E8B41 /* RelationshipsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5CEDC924FC24B1005E8B41 /* RelationshipsManager.swift */; };
+		6D87842724FCD62C003E69CD /* ToOneRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87842624FCD62C003E69CD /* ToOneRelationshipTests.swift */; };
+		6D87842824FCD62C003E69CD /* ToOneRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87842624FCD62C003E69CD /* ToOneRelationshipTests.swift */; };
+		6D87842924FCD62C003E69CD /* ToOneRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87842624FCD62C003E69CD /* ToOneRelationshipTests.swift */; };
+		6D87842B24FCD747003E69CD /* ToManyRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87842A24FCD747003E69CD /* ToManyRelationshipTests.swift */; };
+		6D87842C24FCD747003E69CD /* ToManyRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87842A24FCD747003E69CD /* ToManyRelationshipTests.swift */; };
+		6D87842D24FCD747003E69CD /* ToManyRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87842A24FCD747003E69CD /* ToManyRelationshipTests.swift */; };
+		6D87842F24FCD7C2003E69CD /* RelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87842E24FCD7C2003E69CD /* RelationshipTests.swift */; };
+		6D87843024FCD7C2003E69CD /* RelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87842E24FCD7C2003E69CD /* RelationshipTests.swift */; };
+		6D87843124FCD7C2003E69CD /* RelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87842E24FCD7C2003E69CD /* RelationshipTests.swift */; };
+		6D87843324FCDB7D003E69CD /* RelationshipCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843224FCDB7D003E69CD /* RelationshipCacheTests.swift */; };
+		6D87843424FCDB7D003E69CD /* RelationshipCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843224FCDB7D003E69CD /* RelationshipCacheTests.swift */; };
+		6D87843524FCDB7D003E69CD /* RelationshipCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843224FCDB7D003E69CD /* RelationshipCacheTests.swift */; };
+		6D87843724FCEBC7003E69CD /* RelationshipChildId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843624FCEBC7003E69CD /* RelationshipChildId.swift */; };
+		6D87843824FCEBC7003E69CD /* RelationshipChildId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843624FCEBC7003E69CD /* RelationshipChildId.swift */; };
+		6D87843924FCEBC7003E69CD /* RelationshipChildId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843624FCEBC7003E69CD /* RelationshipChildId.swift */; };
+		6D87843A24FCEBC7003E69CD /* RelationshipChildId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843624FCEBC7003E69CD /* RelationshipChildId.swift */; };
+		6D87843C24FD0069003E69CD /* RelationshipChildIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843B24FD0069003E69CD /* RelationshipChildIdTests.swift */; };
+		6D87843D24FD0069003E69CD /* RelationshipChildIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843B24FD0069003E69CD /* RelationshipChildIdTests.swift */; };
+		6D87843E24FD0069003E69CD /* RelationshipChildIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843B24FD0069003E69CD /* RelationshipChildIdTests.swift */; };
+		6D87844024FD026F003E69CD /* RelationshipManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843F24FD026F003E69CD /* RelationshipManagerTests.swift */; };
+		6D87844124FD026F003E69CD /* RelationshipManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843F24FD026F003E69CD /* RelationshipManagerTests.swift */; };
+		6D87844224FD026F003E69CD /* RelationshipManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D87843F24FD026F003E69CD /* RelationshipManagerTests.swift */; };
 		6F388F5422E73EC50080585F /* RichTextDocumentTransformableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F388F5322E73EC50080585F /* RichTextDocumentTransformableTests.swift */; };
 		6F388F5522E73EC50080585F /* RichTextDocumentTransformableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F388F5322E73EC50080585F /* RichTextDocumentTransformableTests.swift */; };
 		6F388F5622E73EC50080585F /* RichTextDocumentTransformableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F388F5322E73EC50080585F /* RichTextDocumentTransformableTests.swift */; };
@@ -268,6 +310,18 @@
 		5DA9AE0821A2B6AF0033BC4E /* deleted-asset-next.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "deleted-asset-next.json"; sourceTree = "<group>"; };
 		5DD19BA6219F0C940041F483 /* deleted-entry-next.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "deleted-entry-next.json"; sourceTree = "<group>"; };
 		5DD19BAB219F13730041F483 /* deleted-entry-initial.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "deleted-entry-initial.json"; sourceTree = "<group>"; };
+		6D5CEDB524FC2493005E8B41 /* ToManyRelationship.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToManyRelationship.swift; sourceTree = "<group>"; };
+		6D5CEDB624FC2493005E8B41 /* RelationshipCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelationshipCache.swift; sourceTree = "<group>"; };
+		6D5CEDB724FC2493005E8B41 /* Relationship.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Relationship.swift; sourceTree = "<group>"; };
+		6D5CEDB824FC2493005E8B41 /* ToOneRelationship.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToOneRelationship.swift; sourceTree = "<group>"; };
+		6D5CEDC924FC24B1005E8B41 /* RelationshipsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelationshipsManager.swift; sourceTree = "<group>"; };
+		6D87842624FCD62C003E69CD /* ToOneRelationshipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToOneRelationshipTests.swift; sourceTree = "<group>"; };
+		6D87842A24FCD747003E69CD /* ToManyRelationshipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToManyRelationshipTests.swift; sourceTree = "<group>"; };
+		6D87842E24FCD7C2003E69CD /* RelationshipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipTests.swift; sourceTree = "<group>"; };
+		6D87843224FCDB7D003E69CD /* RelationshipCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipCacheTests.swift; sourceTree = "<group>"; };
+		6D87843624FCEBC7003E69CD /* RelationshipChildId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipChildId.swift; sourceTree = "<group>"; };
+		6D87843B24FD0069003E69CD /* RelationshipChildIdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipChildIdTests.swift; sourceTree = "<group>"; };
+		6D87843F24FD026F003E69CD /* RelationshipManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipManagerTests.swift; sourceTree = "<group>"; };
 		6F388F5322E73EC50080585F /* RichTextDocumentTransformableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichTextDocumentTransformableTests.swift; sourceTree = "<group>"; };
 		6F388F5822E73F270080585F /* RichTextDocumentTransformable.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = RichTextDocumentTransformable.xcdatamodel; sourceTree = "<group>"; };
 		6F388F5C22E73FE60080585F /* RichTextDocumentRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichTextDocumentRecord.swift; sourceTree = "<group>"; };
@@ -422,6 +476,32 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6D5CEDB424FC2474005E8B41 /* Relationships */ = {
+			isa = PBXGroup;
+			children = (
+				6D5CEDB724FC2493005E8B41 /* Relationship.swift */,
+				6D5CEDB624FC2493005E8B41 /* RelationshipCache.swift */,
+				6D87843624FCEBC7003E69CD /* RelationshipChildId.swift */,
+				6D5CEDC924FC24B1005E8B41 /* RelationshipsManager.swift */,
+				6D5CEDB524FC2493005E8B41 /* ToManyRelationship.swift */,
+				6D5CEDB824FC2493005E8B41 /* ToOneRelationship.swift */,
+			);
+			path = Relationships;
+			sourceTree = "<group>";
+		};
+		6D87842524FCD612003E69CD /* Relationships */ = {
+			isa = PBXGroup;
+			children = (
+				6D87842E24FCD7C2003E69CD /* RelationshipTests.swift */,
+				6D87842A24FCD747003E69CD /* ToManyRelationshipTests.swift */,
+				6D87842624FCD62C003E69CD /* ToOneRelationshipTests.swift */,
+				6D87843224FCDB7D003E69CD /* RelationshipCacheTests.swift */,
+				6D87843B24FD0069003E69CD /* RelationshipChildIdTests.swift */,
+				6D87843F24FD026F003E69CD /* RelationshipManagerTests.swift */,
+			);
+			path = Relationships;
+			sourceTree = "<group>";
+		};
 		A15B70A61CAD47070019DBCC /* TestModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -617,6 +697,7 @@
 		ED8C1E9C1F617A36001D059F /* ContentfulPersistence */ = {
 			isa = PBXGroup;
 			children = (
+				6D5CEDB424FC2474005E8B41 /* Relationships */,
 				ED10E8841E48AB840061741F /* SynchronizationManager.swift */,
 				ED8C1E711F603939001D059F /* SynchronizationManager+SeedDB.swift */,
 				ED9C21F41EF2C4FB00882ABF /* Persistable.swift */,
@@ -630,6 +711,7 @@
 		ED8C1E9D1F617A8E001D059F /* ContentfulPersistenceTests */ = {
 			isa = PBXGroup;
 			children = (
+				6D87842524FCD612003E69CD /* Relationships */,
 				ED10E8AA1E48AC870061741F /* Info.plist */,
 				ED4C58EC1F161DDE000B65FD /* ContentStubs */,
 				EDCFBF9E1F162449002B1B73 /* Test.xcdatamodeld */,
@@ -1098,6 +1180,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6D5CEDCA24FC24B1005E8B41 /* RelationshipsManager.swift in Sources */,
+				6D5CEDBD24FC2493005E8B41 /* RelationshipCache.swift in Sources */,
+				6D5CEDC524FC2493005E8B41 /* ToOneRelationship.swift in Sources */,
+				6D87843724FCEBC7003E69CD /* RelationshipChildId.swift in Sources */,
+				6D5CEDC124FC2493005E8B41 /* Relationship.swift in Sources */,
+				6D5CEDB924FC2493005E8B41 /* ToManyRelationship.swift in Sources */,
 				ED10E88C1E48AB840061741F /* CoreDataStore.swift in Sources */,
 				ED8C1E721F603939001D059F /* SynchronizationManager+SeedDB.swift in Sources */,
 				ED9C21FA1EF3DBD600882ABF /* PersistenceStore.swift in Sources */,
@@ -1114,13 +1202,16 @@
 				ED10E8B81E48ACBD0061741F /* Asset+CoreDataProperties.swift in Sources */,
 				ED10E8B71E48ACBD0061741F /* Asset.swift in Sources */,
 				6F388F5D22E73FE60080585F /* RichTextDocumentRecord.swift in Sources */,
+				6D87842B24FCD747003E69CD /* ToManyRelationshipTests.swift in Sources */,
 				ED10E8BA1E48ACBD0061741F /* Author+CoreDataProperties.swift in Sources */,
 				ED10E8BE1E48ACBD0061741F /* Post+CoreDataProperties.swift in Sources */,
 				6FCA36BB22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */,
 				6F388F5422E73EC50080585F /* RichTextDocumentTransformableTests.swift in Sources */,
 				ED25D7D81F16654A00A6BA9A /* ComplexSyncTests.swift in Sources */,
+				6D87844024FD026F003E69CD /* RelationshipManagerTests.swift in Sources */,
 				ED10E8B91E48ACBD0061741F /* Author.swift in Sources */,
 				ED10E8BD1E48ACBD0061741F /* Post.swift in Sources */,
+				6D87842F24FCD7C2003E69CD /* RelationshipTests.swift in Sources */,
 				ED10E8C01E48ACBD0061741F /* SyncInfo+CoreDataProperties.swift in Sources */,
 				ED25D7E61F17700900A6BA9A /* ComplexAsset.swift in Sources */,
 				ED25D7E41F176D8E00A6BA9A /* Link+CoreDataProperties.swift in Sources */,
@@ -1129,13 +1220,16 @@
 				ED25D7E01F166C1700A6BA9A /* SingleRecord+CoreDataProperties.swift in Sources */,
 				ED10E8BB1E48ACBD0061741F /* Category.swift in Sources */,
 				6F388F6122E740070080585F /* RichTextDocumentRecord+CoreDataProperties.swift in Sources */,
+				6D87843324FCDB7D003E69CD /* RelationshipCacheTests.swift in Sources */,
 				EDBDBFD21F28B1EB00649F5A /* LocalizationTests.swift in Sources */,
 				6FCA36BF22C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift in Sources */,
 				ED25D7EC1F17709A00A6BA9A /* ComplexSyncInfo+CoreDataProperties.swift in Sources */,
 				EDCFBFA01F162449002B1B73 /* Test.xcdatamodeld in Sources */,
+				6D87843C24FD0069003E69CD /* RelationshipChildIdTests.swift in Sources */,
 				EDBDBFD51F28B23B00649F5A /* LocalizationTest.xcdatamodeld in Sources */,
 				ED4023E620EA5858001C6BDD /* UnresolvedRelationshipCacheTests.swift in Sources */,
 				ED25D7EA1F17706E00A6BA9A /* ComplexSyncInfo.swift in Sources */,
+				6D87842724FCD62C003E69CD /* ToOneRelationshipTests.swift in Sources */,
 				ED10E8C81E48BCAE0061741F /* SynchronizationManagerTests.swift in Sources */,
 				6F388F5922E73F270080585F /* RichTextDocumentTransformableTest.xcdatamodeld in Sources */,
 				ED25D7F51F177D8F00A6BA9A /* ComplexTest.xcdatamodeld in Sources */,
@@ -1151,6 +1245,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6D5CEDCB24FC24B1005E8B41 /* RelationshipsManager.swift in Sources */,
+				6D5CEDBE24FC2493005E8B41 /* RelationshipCache.swift in Sources */,
+				6D5CEDC624FC2493005E8B41 /* ToOneRelationship.swift in Sources */,
+				6D87843824FCEBC7003E69CD /* RelationshipChildId.swift in Sources */,
+				6D5CEDC224FC2493005E8B41 /* Relationship.swift in Sources */,
+				6D5CEDBA24FC2493005E8B41 /* ToManyRelationship.swift in Sources */,
 				ED10E8D71E48BF1D0061741F /* CoreDataStore.swift in Sources */,
 				ED8C1E731F603939001D059F /* SynchronizationManager+SeedDB.swift in Sources */,
 				ED9C21FB1EF3DBD600882ABF /* PersistenceStore.swift in Sources */,
@@ -1164,6 +1264,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6D5CEDCC24FC24B1005E8B41 /* RelationshipsManager.swift in Sources */,
+				6D5CEDBF24FC2493005E8B41 /* RelationshipCache.swift in Sources */,
+				6D5CEDC724FC2493005E8B41 /* ToOneRelationship.swift in Sources */,
+				6D87843924FCEBC7003E69CD /* RelationshipChildId.swift in Sources */,
+				6D5CEDC324FC2493005E8B41 /* Relationship.swift in Sources */,
+				6D5CEDBB24FC2493005E8B41 /* ToManyRelationship.swift in Sources */,
 				ED10E9021E48CD1E0061741F /* CoreDataStore.swift in Sources */,
 				ED8C1E741F603939001D059F /* SynchronizationManager+SeedDB.swift in Sources */,
 				ED9C21FC1EF3DBD600882ABF /* PersistenceStore.swift in Sources */,
@@ -1177,6 +1283,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6D5CEDCD24FC24B1005E8B41 /* RelationshipsManager.swift in Sources */,
+				6D5CEDC024FC2493005E8B41 /* RelationshipCache.swift in Sources */,
+				6D5CEDC824FC2493005E8B41 /* ToOneRelationship.swift in Sources */,
+				6D87843A24FCEBC7003E69CD /* RelationshipChildId.swift in Sources */,
+				6D5CEDC424FC2493005E8B41 /* Relationship.swift in Sources */,
+				6D5CEDBC24FC2493005E8B41 /* ToManyRelationship.swift in Sources */,
 				ED10E9081E48CD1F0061741F /* CoreDataStore.swift in Sources */,
 				ED8C1E751F603939001D059F /* SynchronizationManager+SeedDB.swift in Sources */,
 				ED9C21FD1EF3DBD600882ABF /* PersistenceStore.swift in Sources */,
@@ -1193,13 +1305,16 @@
 				EDD8F4E71F5401E90000D3BB /* ComplexSyncTests.swift in Sources */,
 				EDD8F51B1F5402200000D3BB /* Post.swift in Sources */,
 				6F388F5E22E73FE60080585F /* RichTextDocumentRecord.swift in Sources */,
+				6D87842C24FCD747003E69CD /* ToManyRelationshipTests.swift in Sources */,
 				EDD8F4EB1F5401EF0000D3BB /* TestHelpers.swift in Sources */,
 				EDD8F4E51F5401E50000D3BB /* SynchronizationManagerTests.swift in Sources */,
 				6FCA36BC22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */,
 				6F388F5522E73EC50080585F /* RichTextDocumentTransformableTests.swift in Sources */,
 				EDD8F5071F5402040000D3BB /* Link.swift in Sources */,
+				6D87844124FD026F003E69CD /* RelationshipManagerTests.swift in Sources */,
 				EDD8F5021F5402040000D3BB /* SingleRecord+CoreDataProperties.swift in Sources */,
 				EDD8F5161F5402200000D3BB /* Asset+CoreDataProperties.swift in Sources */,
+				6D87843024FCD7C2003E69CD /* RelationshipTests.swift in Sources */,
 				EDD8F4E91F5401EC0000D3BB /* LocalizationTests.swift in Sources */,
 				EDD8F51C1F5402200000D3BB /* Post+CoreDataProperties.swift in Sources */,
 				EDD8F51A1F5402200000D3BB /* Category+CoreDataProperties.swift in Sources */,
@@ -1208,13 +1323,16 @@
 				EDD8F5041F5402040000D3BB /* ComplexAsset+CoreDataProperties.swift in Sources */,
 				EDD8F51E1F5402200000D3BB /* SyncInfo+CoreDataProperties.swift in Sources */,
 				6F388F6222E740070080585F /* RichTextDocumentRecord+CoreDataProperties.swift in Sources */,
+				6D87843424FCDB7D003E69CD /* RelationshipCacheTests.swift in Sources */,
 				EDD8F5191F5402200000D3BB /* Category.swift in Sources */,
 				6FCA36C022C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift in Sources */,
 				EDD8F5031F5402040000D3BB /* ComplexAsset.swift in Sources */,
 				EDD8F5171F5402200000D3BB /* Author.swift in Sources */,
+				6D87843D24FD0069003E69CD /* RelationshipChildIdTests.swift in Sources */,
 				EDD8F5181F5402200000D3BB /* Author+CoreDataProperties.swift in Sources */,
 				ED4023E720EA5858001C6BDD /* UnresolvedRelationshipCacheTests.swift in Sources */,
 				EDD8F5311F5402E60000D3BB /* ComplexTest.xcdatamodeld in Sources */,
+				6D87842824FCD62C003E69CD /* ToOneRelationshipTests.swift in Sources */,
 				EDD8F51D1F5402200000D3BB /* SyncInfo.swift in Sources */,
 				6F388F5A22E73F270080585F /* RichTextDocumentTransformableTest.xcdatamodeld in Sources */,
 				EDD8F5061F5402040000D3BB /* ComplexSyncInfo+CoreDataProperties.swift in Sources */,
@@ -1233,13 +1351,16 @@
 				EDD8F4E81F5401E90000D3BB /* ComplexSyncTests.swift in Sources */,
 				EDD8F5251F5402200000D3BB /* Post.swift in Sources */,
 				6F388F5F22E73FE60080585F /* RichTextDocumentRecord.swift in Sources */,
+				6D87842D24FCD747003E69CD /* ToManyRelationshipTests.swift in Sources */,
 				EDD8F4EC1F5401EF0000D3BB /* TestHelpers.swift in Sources */,
 				EDD8F4E61F5401E50000D3BB /* SynchronizationManagerTests.swift in Sources */,
 				6FCA36BD22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */,
 				6F388F5622E73EC50080585F /* RichTextDocumentTransformableTests.swift in Sources */,
 				EDD8F50F1F5402040000D3BB /* Link.swift in Sources */,
+				6D87844224FD026F003E69CD /* RelationshipManagerTests.swift in Sources */,
 				EDD8F50A1F5402040000D3BB /* SingleRecord+CoreDataProperties.swift in Sources */,
 				EDD8F5201F5402200000D3BB /* Asset+CoreDataProperties.swift in Sources */,
+				6D87843124FCD7C2003E69CD /* RelationshipTests.swift in Sources */,
 				EDD8F4EA1F5401EC0000D3BB /* LocalizationTests.swift in Sources */,
 				EDD8F5261F5402200000D3BB /* Post+CoreDataProperties.swift in Sources */,
 				EDD8F5241F5402200000D3BB /* Category+CoreDataProperties.swift in Sources */,
@@ -1248,13 +1369,16 @@
 				EDD8F50D1F5402040000D3BB /* ComplexSyncInfo.swift in Sources */,
 				EDD8F50C1F5402040000D3BB /* ComplexAsset+CoreDataProperties.swift in Sources */,
 				6F388F6322E740070080585F /* RichTextDocumentRecord+CoreDataProperties.swift in Sources */,
+				6D87843524FCDB7D003E69CD /* RelationshipCacheTests.swift in Sources */,
 				EDD8F5281F5402200000D3BB /* SyncInfo+CoreDataProperties.swift in Sources */,
 				6FCA36C122C65942004F9A5E /* RecordWithNonOptionalRelation+CoreDataProperties.swift in Sources */,
 				EDD8F5231F5402200000D3BB /* Category.swift in Sources */,
 				EDD8F50B1F5402040000D3BB /* ComplexAsset.swift in Sources */,
+				6D87843E24FD0069003E69CD /* RelationshipChildIdTests.swift in Sources */,
 				EDD8F5211F5402200000D3BB /* Author.swift in Sources */,
 				ED4023E820EA5858001C6BDD /* UnresolvedRelationshipCacheTests.swift in Sources */,
 				EDD8F5221F5402200000D3BB /* Author+CoreDataProperties.swift in Sources */,
+				6D87842924FCD62C003E69CD /* ToOneRelationshipTests.swift in Sources */,
 				EDD8F5271F5402200000D3BB /* SyncInfo.swift in Sources */,
 				6F388F5B22E73F270080585F /* RichTextDocumentTransformableTest.xcdatamodeld in Sources */,
 				EDD8F50E1F5402040000D3BB /* ComplexSyncInfo+CoreDataProperties.swift in Sources */,

--- a/ContentfulPersistenceSwift.podspec
+++ b/ContentfulPersistenceSwift.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |spec|
   spec.watchos.deployment_target = '2.0'
   spec.tvos.deployment_target    = '9.3'
 
-  spec.dependency 'Contentful', '~> 5.0.11'
+  spec.dependency 'Contentful', '~> 5.2.0'
 end
 

--- a/ContentfulPersistenceSwift.podspec
+++ b/ContentfulPersistenceSwift.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
   spec.requires_arc = true
   spec.swift_version             = '5.0'
 
-  spec.source_files              = 'Sources/ContentfulPersistence/*.swift'
+  spec.source_files              = 'Sources/**/*.swift'
   spec.module_name               = 'ContentfulPersistence'
   spec.frameworks                = 'CoreData'
 

--- a/Sources/ContentfulPersistence/Persistable.swift
+++ b/Sources/ContentfulPersistence/Persistable.swift
@@ -35,7 +35,7 @@ public struct PersistenceModel {
 // Protocols are marked with @objc attribute for two reasons:
 // 1) CoreData requires that model classes inherit from `NSManagedObject`
 // 2) @objc enables optional protocol methods that don't require implementation.
-public protocol ContentSysPersistable: class {
+public protocol ContentSysPersistable: NSObject {
     /// The unique identifier of the Resource.
     var id: String { get set }
 

--- a/Sources/ContentfulPersistence/Relationships/Relationship.swift
+++ b/Sources/ContentfulPersistence/Relationships/Relationship.swift
@@ -1,0 +1,57 @@
+//
+//  ContentfulPersistenceSwift
+//
+
+enum Relationship: Codable {
+
+    private enum CodingKeys: CodingKey {
+        case type
+    }
+
+    enum Error: Swift.Error {
+        case invalidRelationship
+    }
+
+    case toOne(ToOneRelationship)
+    case toMany(ToManyRelationship)
+
+    func value<T>() -> T? {
+        switch self {
+        case .toOne(let relationship):
+            return relationship as? T
+        case .toMany(let relationship):
+            return relationship as? T
+        }
+    }
+
+    // MARK: Codable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let typeString = try container.decode(String.self, forKey: .type)
+
+        switch RelationshipType(rawValue: typeString) {
+        case .toOne:
+            self = try .toOne(ToOneRelationship(from: decoder))
+        case .toMany:
+            self = try .toMany(ToManyRelationship(from: decoder))
+        case .none:
+            throw Error.invalidRelationship
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        switch self {
+        case .toOne(let relationship):
+            try relationship.encode(to: encoder)
+        case .toMany(let relationship):
+            try relationship.encode(to: encoder)
+        }
+    }
+}
+
+
+enum RelationshipType: String, Codable {
+    case toOne
+    case toMany
+}

--- a/Sources/ContentfulPersistence/Relationships/RelationshipCache.swift
+++ b/Sources/ContentfulPersistence/Relationships/RelationshipCache.swift
@@ -1,0 +1,105 @@
+//
+//  ContentfulPersistence
+//
+
+import Foundation
+
+/**
+    Stores all relationships in the database. It acts like a backup for relationships in case an entry has been
+    unpublished and is published in the future.
+
+    With this class the library can bring back a relationship on the Core Data Model level. Otherwise, in the
+    following scenario, the model would not reflect a correct state of the model.
+
+    Scenario:
+    1) Fetch all data.
+    2) Unpublish entry that is referenced by other entry.
+    3) See the unpublished entry reference is represented by `nil` in Core Data. Relationship is `nil`.
+    4) Publish entry again.
+    5) See the relationship is broken. The reference is still `nil`. instead of the published entry.
+ */
+final class RelationshipCache {
+
+    private let cacheFileName: String
+
+    // Backing storage for the relationships.
+    private var _relationships = [Relationship]()
+
+    init(cacheFileName: String) {
+        self.cacheFileName = cacheFileName
+    }
+
+    var relationships: [Relationship] {
+        if _relationships.isEmpty {
+            _relationships = loadFromCache()
+        }
+        return _relationships
+    }
+
+    func add(relationship: Relationship) {
+        _relationships.append(relationship)
+    }
+
+    func delete(parentId: String) {
+        _relationships = _relationships.filter { relationship in
+            switch relationship {
+            case .toOne(let nested):
+                return nested.parentId != parentId
+            case .toMany(let nested):
+                return nested.parentId != parentId
+            }
+        }
+    }
+
+    func delete(parentId: String, fieldName: String, localeCode: String?) {
+        _relationships = _relationships.filter { relationship in
+            switch relationship {
+            case .toOne(let nested):
+                return !(nested.parentId == parentId
+                    && nested.fieldName == fieldName
+                    && nested.childId.localeCode == localeCode
+                )
+            case .toMany(let nested):
+                /// All childs in the relationship have the same locale code.
+                return !(nested.parentId == parentId
+                    && nested.fieldName == fieldName
+                    && nested.childIds.first?.localeCode == localeCode
+                )
+            }
+        }
+    }
+
+    func save() {
+        do {
+            guard let localUrl = cacheUrl() else { return }
+
+            let array = try _relationships.compactMap { try JSONEncoder().encode($0) }
+            let data = NSKeyedArchiver.archivedData(withRootObject: array)
+            try data.write(to: localUrl)
+        } catch let error {
+            print("Couldn't persist relationships: \(error)")
+        }
+    }
+
+    private func cacheUrl() -> URL? {
+        guard let url = try? FileManager.default.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) else {
+            return nil
+        }
+
+        return url.appendingPathComponent(cacheFileName)
+    }
+
+    private func loadFromCache() -> [Relationship] {
+        guard let localURL = cacheUrl(),
+            let data = try? Data(contentsOf: localURL, options: []),
+            let array = NSKeyedUnarchiver.unarchiveObject(with: data) as? [Data]
+        else { return [] }
+
+        return (try? array.compactMap { try JSONDecoder().decode(Relationship.self, from: $0) }) ?? []
+    }
+}

--- a/Sources/ContentfulPersistence/Relationships/RelationshipChildId.swift
+++ b/Sources/ContentfulPersistence/Relationships/RelationshipChildId.swift
@@ -1,0 +1,32 @@
+//
+//  ContentfulPersistence
+//
+
+struct RelationshipChildId: Codable, Equatable {
+
+    /// Id of entry that may include locale code.
+    let value: String
+
+    /// Id without locale code.
+    let id: String
+
+    /// Locale code associated with the id.
+    let localeCode: String?
+
+    init(value: String) {
+        self.value = value
+        (self.id, self.localeCode) = value.splitToIdAndLocaleCode()
+    }
+}
+
+private extension String {
+
+    func splitToIdAndLocaleCode() -> (String, String?) {
+        if let index = self.firstIndex(of: "_") {
+            let localeCodeStartIndex = self.index(index, offsetBy: 1)
+            return (String(self[self.startIndex..<index]), String(self[localeCodeStartIndex..<self.endIndex]))
+        } else {
+            return (self, nil)
+        }
+    }
+}

--- a/Sources/ContentfulPersistence/Relationships/RelationshipsManager.swift
+++ b/Sources/ContentfulPersistence/Relationships/RelationshipsManager.swift
@@ -4,7 +4,8 @@
 
 import Foundation
 
-///
+/// Manages relationships of the entries using internal cache. It is used to recreate relationship when
+/// unpublished entry is published again.
 final class RelationshipsManager {
 
     private let cache: RelationshipCache

--- a/Sources/ContentfulPersistence/Relationships/RelationshipsManager.swift
+++ b/Sources/ContentfulPersistence/Relationships/RelationshipsManager.swift
@@ -1,0 +1,72 @@
+//
+//  ContentfulPersistenceSwift
+//
+
+import Foundation
+
+///
+final class RelationshipsManager {
+
+    private let cache: RelationshipCache
+
+    var relationships: [Relationship] {
+        return cache.relationships
+    }
+
+    init(cacheFileName: String) {
+        self.cache = RelationshipCache(cacheFileName: cacheFileName)
+    }
+
+    /// Creates one-to-one relationship if does not exist yet.
+    func cacheToOneRelationship(
+        parent: EntryPersistable,
+        childId: String,
+        fieldName: String
+    ) {
+        let theChildId = RelationshipChildId(value: childId)
+        delete(parentId: parent.id, fieldName: fieldName, localeCode: theChildId.localeCode)
+
+        let parentType = type(of: parent).contentTypeId
+
+        let relationship = ToOneRelationship(
+            parentType: parentType,
+            parentId: parent.id,
+            fieldName: fieldName,
+            childId: .init(value: childId)
+        )
+
+        cache.add(relationship: .toOne(relationship))
+    }
+
+    func cacheToManyRelationship(
+        parent: EntryPersistable,
+        childIds: [String],
+        fieldName: String
+    ) {
+        let theChildIds: [RelationshipChildId] = childIds.map { .init(value: $0) }
+        delete(parentId: parent.id, fieldName: fieldName, localeCode: theChildIds.first?.localeCode)
+
+        let parentType = type(of: parent).contentTypeId
+
+        let relationship = ToManyRelationship(
+            parentType: parentType,
+            parentId: parent.id,
+            fieldName: fieldName,
+            childIds: theChildIds
+        )
+
+        cache.add(relationship: .toMany(relationship))
+    }
+
+    func delete(parentId: String) {
+        cache.delete(parentId: parentId)
+    }
+
+    func delete(parentId: String, fieldName: String, localeCode: String?) {
+        cache.delete(parentId: parentId, fieldName: fieldName, localeCode: localeCode)
+    }
+
+    func save() {
+        cache.save()
+    }
+}

--- a/Sources/ContentfulPersistence/Relationships/ToManyRelationship.swift
+++ b/Sources/ContentfulPersistence/Relationships/ToManyRelationship.swift
@@ -1,0 +1,16 @@
+//
+//  ContentfulPersistence
+//
+
+/// Represents one-to-many relationship between two entries.
+struct ToManyRelationship: Codable, Equatable {
+
+    let type: RelationshipType = .toMany
+
+    /// `EntryPersistable.contentTypeId`
+    var parentType: String
+
+    var parentId: String
+    let fieldName: String
+    var childIds: [RelationshipChildId]
+}

--- a/Sources/ContentfulPersistence/Relationships/ToOneRelationship.swift
+++ b/Sources/ContentfulPersistence/Relationships/ToOneRelationship.swift
@@ -1,0 +1,16 @@
+//
+//  ContentfulPersistence
+//
+
+/// Represents one-to-one between two elements.
+struct ToOneRelationship: Codable, Equatable {
+
+    let type: RelationshipType = .toOne
+
+    /// `EntryPersistable.contentTypeId`
+    var parentType: String
+
+    var parentId: String
+    let fieldName: String
+    var childId: RelationshipChildId
+}

--- a/Tests/ContentfulPersistenceTests/Relationships/RelationshipCacheTests.swift
+++ b/Tests/ContentfulPersistenceTests/Relationships/RelationshipCacheTests.swift
@@ -21,7 +21,10 @@ class RelationshipCacheTests: XCTestCase {
 
         // Verify
         let verifyCache = RelationshipCache(cacheFileName: fileName)
-        XCTAssertEqual(verifyCache.relationships.count, 3)
+
+        verifyCache.add(relationship: .toOne(makeToOne1(localeCode: "en-US")))
+
+        XCTAssertEqual(verifyCache.relationships.count, 4)
     }
 
     func test_relationship_isDeleted() {

--- a/Tests/ContentfulPersistenceTests/Relationships/RelationshipCacheTests.swift
+++ b/Tests/ContentfulPersistenceTests/Relationships/RelationshipCacheTests.swift
@@ -1,0 +1,151 @@
+//
+//  ContentfulPersistence
+//
+
+@testable import ContentfulPersistence
+import XCTest
+
+class RelationshipCacheTests: XCTestCase {
+
+    func test_relationships_areCachedOnDisk() {
+        let fileName = makeFileName()
+        let cache = RelationshipCache(cacheFileName: fileName)
+
+        XCTAssertEqual(cache.relationships.count, 0)
+
+        cache.add(relationship: .toOne(makeToOne1()))
+        cache.add(relationship: .toOne(makeToOne2()))
+        cache.add(relationship: .toMany(makeToMany1()))
+
+        cache.save()
+
+        // Verify
+        let verifyCache = RelationshipCache(cacheFileName: fileName)
+        XCTAssertEqual(verifyCache.relationships.count, 3)
+    }
+
+    func test_relationship_isDeleted() {
+        let fileName = makeFileName()
+        let cache = RelationshipCache(cacheFileName: fileName)
+
+        XCTAssertEqual(cache.relationships.count, 0)
+
+        cache.add(relationship: .toOne(makeToOne1()))
+
+        let toOne2 = makeToOne2()
+        cache.add(relationship: .toOne(toOne2))
+
+        let toMany1 = makeToMany1()
+        cache.add(relationship: .toMany(toMany1))
+
+        XCTAssertEqual(cache.relationships.count, 3)
+
+        cache.delete(parentId: toOne2.parentId)
+        XCTAssertEqual(cache.relationships.count, 2)
+
+        cache.delete(parentId: toMany1.parentId)
+        XCTAssertEqual(cache.relationships.count, 1)
+
+        cache.add(relationship: .toOne(toOne2))
+        cache.add(relationship: .toMany(toMany1))
+
+        cache.delete(
+            parentId: toOne2.parentId,
+            fieldName: toOne2.fieldName,
+            localeCode: toOne2.childId.localeCode
+        )
+
+        XCTAssertEqual(cache.relationships.count, 2)
+
+        cache.delete(
+            parentId: toMany1.parentId,
+            fieldName: toMany1.fieldName,
+            localeCode: toMany1.childIds.first?.localeCode
+        )
+
+        XCTAssertEqual(cache.relationships.count, 1)
+    }
+
+    func test_deleteRelationship_byLocale() {
+        let fileName = makeFileName()
+        let cache = RelationshipCache(cacheFileName: fileName)
+
+        XCTAssertEqual(cache.relationships.count, 0)
+
+        let toOne1a = makeToOne1(localeCode: "en-US")
+        let toOne1b = makeToOne1(localeCode: "pl-PL")
+        cache.add(relationship: .toOne(toOne1a))
+        cache.add(relationship: .toOne(toOne1b))
+
+        cache.delete(
+            parentId: toOne1a.parentId,
+            fieldName: toOne1a.fieldName,
+            localeCode: nil
+        )
+
+        XCTAssertEqual(cache.relationships.count, 2)
+
+        cache.delete(
+            parentId: toOne1a.parentId,
+            fieldName: toOne1a.fieldName,
+            localeCode: "en-GB"
+        )
+
+        XCTAssertEqual(cache.relationships.count, 2)
+
+        cache.delete(
+            parentId: toOne1a.parentId,
+            fieldName: toOne1a.fieldName,
+            localeCode: toOne1a.childId.localeCode
+        )
+
+        XCTAssertEqual(cache.relationships.count, 1)
+
+        cache.delete(
+            parentId: toOne1b.parentId,
+            fieldName: toOne1b.fieldName,
+            localeCode: toOne1b.childId.localeCode
+        )
+
+        XCTAssertEqual(cache.relationships.count, 0)
+    }
+
+    private func makeToOne1(localeCode: String? = nil) -> ToOneRelationship {
+        var childId = "dog-1"
+        if let localeCode = localeCode {
+            childId += "_\(localeCode)"
+        }
+
+        return .init(
+            parentType: "person",
+            parentId: "person-1",
+            fieldName: "dog",
+            childId: .init(value: childId)
+        )
+    }
+
+    private func makeToOne2() -> ToOneRelationship {
+        .init(
+            parentType: "person",
+            parentId: "person-2",
+            fieldName: "cat",
+            childId: .init(value: "cat-1")
+        )
+    }
+
+    private func makeToMany1() -> ToManyRelationship {
+        .init(
+            parentType: "person",
+            parentId: "person-3",
+            fieldName: "things",
+            childIds: [
+                .init(value: "cat-1"),
+                .init(value: "dog-2")
+            ]
+        )
+    }
+
+    private func makeFileName() -> String {
+        UUID().uuidString + "-\(Date().timeIntervalSince1970)"
+    }
+}

--- a/Tests/ContentfulPersistenceTests/Relationships/RelationshipChildIdTests.swift
+++ b/Tests/ContentfulPersistenceTests/Relationships/RelationshipChildIdTests.swift
@@ -1,0 +1,28 @@
+//
+//  ContentfulPersistence
+//
+
+@testable import ContentfulPersistence
+import XCTest
+
+class RelationshipChildIdTests: XCTestCase {
+
+    func test_idAndLocale_areSet() {
+        let id = "abc-def"
+        let localeCode = "en-US"
+
+        let value = "\(id)_\(localeCode)"
+
+        let childId = RelationshipChildId(value: value)
+        XCTAssertEqual(childId.id, id)
+        XCTAssertEqual(childId.localeCode, localeCode)
+    }
+
+    func test_id_isSet() {
+        let id = "abc-def"
+
+        let childId = RelationshipChildId(value: id)
+        XCTAssertEqual(childId.id, id)
+        XCTAssertNil(childId.localeCode)
+    }
+}

--- a/Tests/ContentfulPersistenceTests/Relationships/RelationshipManagerTests.swift
+++ b/Tests/ContentfulPersistenceTests/Relationships/RelationshipManagerTests.swift
@@ -1,0 +1,119 @@
+//
+//  ContentfulPersistence
+//
+
+import Contentful
+@testable import ContentfulPersistence
+import XCTest
+
+class RelationshipManagerTests: XCTestCase {
+
+    func test_manager_worksCorrectly() {
+        let manager = RelationshipsManager(cacheFileName: makeFileName())
+
+        let entry1 = EntryA(id: "person-1")
+
+        for _ in 0..<5 {
+            manager.cacheToOneRelationship(
+                parent: entry1,
+                childId: "dog-1",
+                fieldName: "dog"
+            )
+        }
+
+        XCTAssertEqual(manager.relationships.count, 1)
+
+        let entry2 = EntryA(id: "person-2")
+
+        for _ in 0..<5 {
+            manager.cacheToOneRelationship(
+                parent: entry2,
+                childId: "dog-1",
+                fieldName: "dog"
+            )
+        }
+
+        XCTAssertEqual(manager.relationships.count, 2)
+
+        for _ in 0..<5 {
+            manager.cacheToManyRelationship(
+                parent: entry1,
+                childIds: [
+                    "cat-1",
+                    "cat-2",
+                    "cat-3"
+                ],
+                fieldName: "cats"
+            )
+        }
+
+        XCTAssertEqual(manager.relationships.count, 3)
+
+        manager.delete(parentId: entry1.id, fieldName: "cats", localeCode: nil)
+        XCTAssertEqual(manager.relationships.count, 2)
+
+        manager.delete(parentId: entry2.id)
+        XCTAssertEqual(manager.relationships.count, 1)
+
+        manager.delete(parentId: entry1.id)
+        XCTAssertEqual(manager.relationships.count, 0)
+    }
+
+    private func makeToOne1(localeCode: String? = nil) -> ToOneRelationship {
+        var childId = "dog-1"
+        if let localeCode = localeCode {
+            childId += "_\(localeCode)"
+        }
+
+        return .init(
+            parentType: "person",
+            parentId: "person-1",
+            fieldName: "dog",
+            childId: .init(value: childId)
+        )
+    }
+
+    private func makeToOne2() -> ToOneRelationship {
+        .init(
+            parentType: "person",
+            parentId: "person-2",
+            fieldName: "cat",
+            childId: .init(value: "cat-1")
+        )
+    }
+
+    private func makeToMany1() -> ToManyRelationship {
+        .init(
+            parentType: "person",
+            parentId: "person-3",
+            fieldName: "things",
+            childIds: [
+                .init(value: "cat-1"),
+                .init(value: "dog-2")
+            ]
+        )
+    }
+
+    private func makeFileName() -> String {
+        UUID().uuidString + "-\(Date().timeIntervalSince1970)"
+    }
+}
+
+private class EntryA: NSObject, EntryPersistable {
+
+    static var contentTypeId: ContentTypeId = "entry-a"
+
+    static func fieldMapping() -> [FieldName : String] {
+        [:]
+    }
+
+    var id: String
+    var localeCode: String?
+    var updatedAt: Date? = nil
+    var createdAt: Date? = nil
+
+    init(id: String = "", localeCode: String? = nil) {
+        self.id = id
+        self.localeCode = localeCode
+    }
+}

--- a/Tests/ContentfulPersistenceTests/Relationships/RelationshipTests.swift
+++ b/Tests/ContentfulPersistenceTests/Relationships/RelationshipTests.swift
@@ -1,0 +1,37 @@
+//
+//  ContentfulPersistence
+//
+
+@testable import ContentfulPersistence
+import XCTest
+
+class RelationshipTests: XCTestCase {
+
+    func testToOneRelationshipValue() {
+        let nested = ToOneRelationship(
+            parentType: "1",
+            parentId: "2",
+            fieldName: "3",
+            childId: .init(value: "4")
+        )
+
+        let relationship = Relationship.toOne(nested)
+
+        let value: ToOneRelationship? = relationship.value()
+        XCTAssertEqual(value, nested)
+    }
+
+    func testToManyRelationshipValue() {
+        let nested = ToManyRelationship(
+            parentType: "1",
+            parentId: "2",
+            fieldName: "3",
+            childIds: [.init(value: "4"), .init(value: "5")]
+        )
+
+        let relationship = Relationship.toMany(nested)
+
+        let value: ToManyRelationship? = relationship.value()
+        XCTAssertEqual(value, nested)
+    }
+}

--- a/Tests/ContentfulPersistenceTests/Relationships/ToManyRelationshipTests.swift
+++ b/Tests/ContentfulPersistenceTests/Relationships/ToManyRelationshipTests.swift
@@ -1,0 +1,20 @@
+//
+//  ContentfulPersistence
+//
+
+@testable import ContentfulPersistence
+import XCTest
+
+class ToManyRelationshipTests: XCTestCase {
+
+    func testRelationship() {
+        let relationship = ToManyRelationship(
+            parentType: "1",
+            parentId: "2",
+            fieldName: "3",
+            childIds: [.init(value: "4"), .init(value: "5")]
+        )
+
+        XCTAssertEqual(relationship.type, RelationshipType.toMany)
+    }
+}

--- a/Tests/ContentfulPersistenceTests/Relationships/ToOneRelationshipTests.swift
+++ b/Tests/ContentfulPersistenceTests/Relationships/ToOneRelationshipTests.swift
@@ -1,0 +1,20 @@
+//
+//  ContentfulPersistence
+//
+
+@testable import ContentfulPersistence
+import XCTest
+
+class ToOneRelationshipTests: XCTestCase {
+
+    func testRelationship() {
+        let relationship = ToOneRelationship(
+            parentType: "1",
+            parentId: "2",
+            fieldName: "3",
+            childId: .init(value: "4")
+        )
+
+        XCTAssertEqual(relationship.type, RelationshipType.toOne)
+    }
+}


### PR DESCRIPTION
Added entries relationship caching (one-to-one and one-to-many)

When a referenced entry is published, unpublished and published again, without relationship caching
the relationship on the core data level was still set to nil instead of referencing the existing entry.

SynchronizationManager maintain a list of relationships in the model with respect to locale codes 
and uses that list to recreate relationships between newly created entries and their parents.

Relationships are cached in a file on disk.

When this is merged the sync token should be removed and content should be synced again to let the RelationshipCache to cache all the relationships.

Resolves #94 