### PR TITLE
Transformable support for symbol array encoding/decoding

### DIFF
--- a/Sources/ContentfulPersistence/SynchronizationManager.swift
+++ b/Sources/ContentfulPersistence/SynchronizationManager.swift
@@ -589,11 +589,12 @@ public class SynchronizationManager: PersistenceIntegration {
         for (fieldName, propertyName) in mapping {
             var fieldValue = entry.fields[fieldName]
 
-            // handle symbol arrays
-            if let array = fieldValue as? [Any] {
+            let attributeType = persistable.entity.attributesByName[fieldName]?.attributeType
+            // handle symbol arrays as NSData if field is of type .binaryDataAttributeType, otherwise use .transformableAttributeType
+            if attributeType == .binaryDataAttributeType, let array = fieldValue as? [Codable] {
                 fieldValue = NSKeyedArchiver.archivedData(withRootObject: array)
             }
-            if persistable.entity.attributesByName[fieldName]?.attributeType == .dateAttributeType, let date = getDate(fieldValue as? String) {
+            if attributeType == .dateAttributeType, let date = getDate(fieldValue as? String) {
                 fieldValue = date
             }
             persistable.setValue(fieldValue, forKey: propertyName)

--- a/Sources/ContentfulPersistence/SynchronizationManager.swift
+++ b/Sources/ContentfulPersistence/SynchronizationManager.swift
@@ -591,7 +591,7 @@ public class SynchronizationManager: PersistenceIntegration {
 
             let attributeType = persistable.entity.attributesByName[fieldName]?.attributeType
             // handle symbol arrays as NSData if field is of type .binaryDataAttributeType, otherwise use .transformableAttributeType
-            if attributeType == .binaryDataAttributeType, let array = fieldValue as? [Codable] {
+            if attributeType == .binaryDataAttributeType, let array = fieldValue as? [NSCoding] {
                 fieldValue = NSKeyedArchiver.archivedData(withRootObject: array)
             }
             if attributeType == .dateAttributeType, let date = getDate(fieldValue as? String) {

--- a/Tests/ContentfulPersistenceTests/ComplexSyncTests.swift
+++ b/Tests/ContentfulPersistenceTests/ComplexSyncTests.swift
@@ -714,6 +714,15 @@ class ComplexSyncTests: XCTestCase {
                 } else {
                     XCTFail("There should be an array of linked strings")
                 }
+                
+                if let linkedStringsArray = records.first?.symbolsArrayTransformable {
+                    XCTAssertFalse(records.first!.hasChanges, "Record has not yet been saved")
+                    XCTAssertEqual(linkedStringsArray.count, 5)
+                    XCTAssertEqual(linkedStringsArray.first, "one")
+                    XCTAssertEqual(linkedStringsArray.last, "five")
+                } else {
+                    XCTFail("There should be an array of linked strings")
+                }
             case .failure(let error):
                 XCTFail("Should not throw an error \(error)")
             }

--- a/Tests/ContentfulPersistenceTests/ComplexTest.xcdatamodeld/ComplexTest.xcdatamodel/contents
+++ b/Tests/ContentfulPersistenceTests/ComplexTest.xcdatamodeld/ComplexTest.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.99" systemVersion="18G48f" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17192" systemVersion="19H2" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ComplexAsset" representedClassName="ComplexAsset" syncable="YES">
         <attribute name="assetDescription" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -42,6 +42,7 @@
         <attribute name="locationField" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="postedDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="symbolsArray" optional="YES" attributeType="Binary" customClassName="NSString" syncable="YES"/>
+        <attribute name="symbolsArrayTransformable" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="textBody" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="assetLinkField" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ComplexAsset" inverseName="singleRecordAssetLinkInverse" inverseEntity="ComplexAsset" syncable="YES"/>
@@ -53,6 +54,6 @@
         <element name="ComplexSyncInfo" positionX="-54" positionY="-9" width="128" height="60"/>
         <element name="Link" positionX="-18" positionY="99" width="128" height="150"/>
         <element name="RecordWithNonOptionalRelation" positionX="-36" positionY="126" width="128" height="120"/>
-        <element name="SingleRecord" positionX="-36" positionY="90" width="128" height="210"/>
+        <element name="SingleRecord" positionX="-36" positionY="90" width="128" height="223"/>
     </elements>
 </model>

--- a/Tests/ContentfulPersistenceTests/ComplexTestModels/SingleRecord+CoreDataProperties.swift
+++ b/Tests/ContentfulPersistenceTests/ComplexTestModels/SingleRecord+CoreDataProperties.swift
@@ -26,6 +26,7 @@ extension SingleRecord: EntryPersistable {
     @NSManaged var assetLinkField: ComplexAsset?
     @NSManaged var assetsArrayLinkField: NSOrderedSet?
     @NSManaged var symbolsArray: Data?
+    @NSManaged var symbolsArrayTransformable: [String]?
     
     static func fieldMapping() -> [FieldName: String] {
         return [
@@ -35,7 +36,8 @@ extension SingleRecord: EntryPersistable {
             "postedDate": "postedDate",
             "assetLinkField": "assetLinkField",
             "assetsArrayLinkField": "assetsArrayLinkField",
-            "symbolsArray": "symbolsArray"
+            "symbolsArray": "symbolsArray",
+            "symbolsArrayTransformable": "symbolsArrayTransformable"
         ]
     }
 }

--- a/Tests/ContentfulPersistenceTests/ComplexTestStubs/symbols-array.json
+++ b/Tests/ContentfulPersistenceTests/ComplexTestStubs/symbols-array.json
@@ -37,6 +37,15 @@
             "four",
             "five"
           ]
+        },
+        "symbolsArrayTransformable": {
+          "en-US": [
+            "one",
+            "two",
+            "three",
+            "four",
+            "five"
+          ]
         }
       }
     }

--- a/Tests/ContentfulPersistenceTests/LocalizationTest.xcdatamodeld/LocalizationTest.xcdatamodel/contents
+++ b/Tests/ContentfulPersistenceTests/LocalizationTest.xcdatamodeld/LocalizationTest.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="17G3025" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17192" systemVersion="19H2" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ComplexAsset" representedClassName="ComplexAsset" syncable="YES">
         <attribute name="assetDescription" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -34,6 +34,7 @@
         <attribute name="locationField" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="postedDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="symbolsArray" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="symbolsArrayTransformable" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="textBody" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="assetLinkField" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ComplexAsset" inverseName="singleRecordAssetLinkInverse" inverseEntity="ComplexAsset" syncable="YES"/>
@@ -44,6 +45,6 @@
         <element name="ComplexAsset" positionX="-63" positionY="-18" width="128" height="255"/>
         <element name="ComplexSyncInfo" positionX="-54" positionY="-9" width="128" height="60"/>
         <element name="Link" positionX="-18" positionY="99" width="128" height="135"/>
-        <element name="SingleRecord" positionX="-36" positionY="90" width="128" height="210"/>
+        <element name="SingleRecord" positionX="-36" positionY="90" width="128" height="223"/>
     </elements>
 </model>

--- a/Tests/ContentfulPersistenceTests/MultilocalePreseedJSONFiles/0.json
+++ b/Tests/ContentfulPersistenceTests/MultilocalePreseedJSONFiles/0.json
@@ -44,6 +44,15 @@
             "four",
             "five"
           ]
+        },
+        "symbolsArrayTransformable": {
+          "en-US": [
+            "one",
+            "two",
+            "three",
+            "four",
+            "five"
+          ]
         }
       }
     },


### PR DESCRIPTION
This PR adds the ability to define symbol arrays as `Transformable` in Core Data.

This option simplifies using symbol arrays in the content model because the decodable type infers from the managed object's property type without manual decoding.

<img width="384" alt="Screenshot 2020-11-21 at 01 10 50" src="https://user-images.githubusercontent.com/213965/99861549-b82d5700-2b96-11eb-8e1b-ced5a2903cdf.png">

<img width="712" alt="Screenshot 2020-11-21 at 01 10 25" src="https://user-images.githubusercontent.com/213965/99861551-b95e8400-2b96-11eb-9570-b25a455eeab3.png">
