### PR TITLE
Speed up localization synching

### DIFF
--- a/Sources/ContentfulPersistence/SynchronizationManager.swift
+++ b/Sources/ContentfulPersistence/SynchronizationManager.swift
@@ -398,12 +398,13 @@ public class SynchronizationManager: PersistenceIntegration {
 
         let fetchPredicate = predicate(for: entry.id, localeCodes: localeCodes)
         let fetchedEntries: [EntryPersistable] = (try? persistentStore.fetchAll(type: type, predicate: fetchPredicate)) ?? []
+        let localeToEntryDict = Dictionary(grouping: fetchedEntries, by: { $0.localeCode })
 
         for localeCode in localeCodes {
             entry.setLocale(withCode: localeCode)
             let persistable: EntryPersistable
 
-            if let fetched = (fetchedEntries.first { $0.localeCode == localeCode }) {
+            if let fetched = localeToEntryDict[localeCode]?.first {
                 persistable = fetched
             } else {
                 do {


### PR DESCRIPTION
We noticed the same crashes when updating entries that have been fixed in the latest 0.17.2 release (https://github.com/contentful/contentful-persistence.swift/commit/bb43c169798a5088b1fa1eec4b5eaa8e3ab9d0cb).

I have compared our 2 fixes and found out that our solution has a better performance when there are multiple locales. Did a few time measurements on the different environments we have. They each have 2-4 localizations.
I can attach some measured times if you are interested. 

This commit optimizes the locales loop from O(L^2) to O(L) runtime by using a dictionary lookup instead of a linear array search. This especially increases performance when there are many localizations.