### PR TITLE
Improved fetching CoreData entities by batch of records, not by one

### DIFF
--- a/ContentfulPersistence.xcodeproj/project.pbxproj
+++ b/ContentfulPersistence.xcodeproj/project.pbxproj
@@ -103,6 +103,15 @@
 		6FD0311922CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FD0311822CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json */; };
 		6FD0311A22CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FD0311822CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json */; };
 		6FD0311B22CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FD0311822CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json */; };
+		AE1A2B912684BE4E00904D31 /* BatchSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1A2B902684BE4E00904D31 /* BatchSyncTests.swift */; };
+		AE1A2B922684BE4E00904D31 /* BatchSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1A2B902684BE4E00904D31 /* BatchSyncTests.swift */; };
+		AE1A2B932684BE4E00904D31 /* BatchSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1A2B902684BE4E00904D31 /* BatchSyncTests.swift */; };
+		AE1A2B962685166B00904D31 /* batch-update-initial-sync-page2.json in Resources */ = {isa = PBXBuildFile; fileRef = AE1A2B942685166B00904D31 /* batch-update-initial-sync-page2.json */; };
+		AE1A2B972685166B00904D31 /* batch-update-initial-sync-page2.json in Resources */ = {isa = PBXBuildFile; fileRef = AE1A2B942685166B00904D31 /* batch-update-initial-sync-page2.json */; };
+		AE1A2B982685166B00904D31 /* batch-update-initial-sync-page2.json in Resources */ = {isa = PBXBuildFile; fileRef = AE1A2B942685166B00904D31 /* batch-update-initial-sync-page2.json */; };
+		AE1A2B992685166B00904D31 /* batch-update-initial-sync.json in Resources */ = {isa = PBXBuildFile; fileRef = AE1A2B952685166B00904D31 /* batch-update-initial-sync.json */; };
+		AE1A2B9A2685166B00904D31 /* batch-update-initial-sync.json in Resources */ = {isa = PBXBuildFile; fileRef = AE1A2B952685166B00904D31 /* batch-update-initial-sync.json */; };
+		AE1A2B9B2685166B00904D31 /* batch-update-initial-sync.json in Resources */ = {isa = PBXBuildFile; fileRef = AE1A2B952685166B00904D31 /* batch-update-initial-sync.json */; };
 		ED10E88B1E48AB840061741F /* SynchronizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED10E8841E48AB840061741F /* SynchronizationManager.swift */; };
 		ED10E88C1E48AB840061741F /* CoreDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED10E8851E48AB840061741F /* CoreDataStore.swift */; };
 		ED10E88D1E48AB840061741F /* DataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED10E8861E48AB840061741F /* DataCache.swift */; };
@@ -337,6 +346,9 @@
 		6FD0311822CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "multi-page-non-optional-link-resolution2.json"; sourceTree = "<group>"; };
 		A1A9FBE31CABE8EA00430734 /* ContentfulPersistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ContentfulPersistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1A9FBED1CABE8EA00430734 /* ContentfulPersistenceTests_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContentfulPersistenceTests_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE1A2B902684BE4E00904D31 /* BatchSyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatchSyncTests.swift; sourceTree = "<group>"; };
+		AE1A2B942685166B00904D31 /* batch-update-initial-sync-page2.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "batch-update-initial-sync-page2.json"; sourceTree = "<group>"; };
+		AE1A2B952685166B00904D31 /* batch-update-initial-sync.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "batch-update-initial-sync.json"; sourceTree = "<group>"; };
 		ED10E8841E48AB840061741F /* SynchronizationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SynchronizationManager.swift; sourceTree = "<group>"; };
 		ED10E8851E48AB840061741F /* CoreDataStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataStore.swift; sourceTree = "<group>"; };
 		ED10E8861E48AB840061741F /* DataCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataCache.swift; sourceTree = "<group>"; };
@@ -602,6 +614,8 @@
 		ED25D7F61F17900900A6BA9A /* ComplexTestStubs */ = {
 			isa = PBXGroup;
 			children = (
+				AE1A2B942685166B00904D31 /* batch-update-initial-sync-page2.json */,
+				AE1A2B952685166B00904D31 /* batch-update-initial-sync.json */,
 				ED4023ED20EA5D43001C6BDD /* now-resolvable-relationships.json */,
 				5DA9AE0721A2B6AF0033BC4E /* deleted-asset-initial.json */,
 				5DA9AE0821A2B6AF0033BC4E /* deleted-asset-next.json */,
@@ -726,6 +740,7 @@
 				ED25D7DC1F166B7300A6BA9A /* ComplexTestModels */,
 				ED25D7F61F17900900A6BA9A /* ComplexTestStubs */,
 				ED25D7D71F16654A00A6BA9A /* ComplexSyncTests.swift */,
+				AE1A2B902684BE4E00904D31 /* BatchSyncTests.swift */,
 				ED4023E520EA5858001C6BDD /* UnresolvedRelationshipCacheTests.swift */,
 				ED10E8A71E48AC870061741F /* SynchronizationManagerTests.swift */,
 				EDBDBFD31F28B23B00649F5A /* LocalizationTest.xcdatamodeld */,
@@ -1004,6 +1019,7 @@
 				6FD0311522CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json in Resources */,
 				5DA9AE0C21A2B6AF0033BC4E /* deleted-asset-next.json in Resources */,
 				ED91F99E1F18C79D00540DAC /* multi-page-link-resolution1.json in Resources */,
+				AE1A2B962685166B00904D31 /* batch-update-initial-sync-page2.json in Resources */,
 				EDCFBF9D1F161EB6002B1B73 /* single-author.json in Resources */,
 				ED6B67981F191342008EC7C8 /* clear-field-initial-sync.json in Resources */,
 				5DD19BAA219F0C980041F483 /* deleted-entry-next.json in Resources */,
@@ -1014,6 +1030,7 @@
 				ED1BA7D01F16288100E21FD5 /* space.json in Resources */,
 				ED8C1E881F6175A5001D059F /* MultifilePreseedJSONFiles in Resources */,
 				ED91F99F1F18C79D00540DAC /* multi-page-link-resolution2.json in Resources */,
+				AE1A2B992685166B00904D31 /* batch-update-initial-sync.json in Resources */,
 				6FD0311922CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */,
 				ED79E9281FCC23E10045F44F /* MultilocalePreseedJSONFiles in Resources */,
 				EDE5BA39207220F900A650FE /* video-asset.json in Resources */,
@@ -1061,6 +1078,7 @@
 				6FD0311622CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json in Resources */,
 				5DA9AE0D21A2B6AF0033BC4E /* deleted-asset-next.json in Resources */,
 				EDD8F52B1F5402290000D3BB /* single-author.json in Resources */,
+				AE1A2B972685166B00904D31 /* batch-update-initial-sync-page2.json in Resources */,
 				EDD8F4F51F5401FD0000D3BB /* simple-update-initial-sync.json in Resources */,
 				EDD8F4F41F5401FD0000D3BB /* multi-page-link-resolution2.json in Resources */,
 				5DD19BA9219F0C980041F483 /* deleted-entry-next.json in Resources */,
@@ -1071,6 +1089,7 @@
 				EDD8F4EF1F5401FD0000D3BB /* clear-field-initial-sync.json in Resources */,
 				ED8C1E891F6175A5001D059F /* MultifilePreseedJSONFiles in Resources */,
 				EDD8F4ED1F5401F50000D3BB /* localization-sync.json in Resources */,
+				AE1A2B9A2685166B00904D31 /* batch-update-initial-sync.json in Resources */,
 				6FD0311A22CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */,
 				ED79E9291FCC23E10045F44F /* MultilocalePreseedJSONFiles in Resources */,
 				EDE5BA3A207220FA00A650FE /* video-asset.json in Resources */,
@@ -1097,6 +1116,7 @@
 				6FD0311722CE3A4600790FDB /* multi-page-non-optional-link-resolution1.json in Resources */,
 				5DA9AE0E21A2B6AF0033BC4E /* deleted-asset-next.json in Resources */,
 				EDD8F52E1F5402290000D3BB /* single-author.json in Resources */,
+				AE1A2B982685166B00904D31 /* batch-update-initial-sync-page2.json in Resources */,
 				EDD8F4FE1F5401FD0000D3BB /* simple-update-initial-sync.json in Resources */,
 				EDD8F4FD1F5401FD0000D3BB /* multi-page-link-resolution2.json in Resources */,
 				5DD19BA8219F0C980041F483 /* deleted-entry-next.json in Resources */,
@@ -1107,6 +1127,7 @@
 				EDD8F4F81F5401FD0000D3BB /* clear-field-initial-sync.json in Resources */,
 				ED8C1E8A1F6175A5001D059F /* MultifilePreseedJSONFiles in Resources */,
 				EDD8F4EE1F5401F60000D3BB /* localization-sync.json in Resources */,
+				AE1A2B9B2685166B00904D31 /* batch-update-initial-sync.json in Resources */,
 				6FD0311B22CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json in Resources */,
 				ED79E92A1FCC23E10045F44F /* MultilocalePreseedJSONFiles in Resources */,
 				EDE5BA3B207220FA00A650FE /* video-asset.json in Resources */,
@@ -1215,6 +1236,7 @@
 				6FCA36BB22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */,
 				6F388F5422E73EC50080585F /* RichTextDocumentTransformableTests.swift in Sources */,
 				ED25D7D81F16654A00A6BA9A /* ComplexSyncTests.swift in Sources */,
+				AE1A2B912684BE4E00904D31 /* BatchSyncTests.swift in Sources */,
 				6D87844024FD026F003E69CD /* RelationshipManagerTests.swift in Sources */,
 				ED10E8B91E48ACBD0061741F /* Author.swift in Sources */,
 				ED10E8BD1E48ACBD0061741F /* Post.swift in Sources */,
@@ -1321,6 +1343,7 @@
 				6FCA36BC22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */,
 				6F388F5522E73EC50080585F /* RichTextDocumentTransformableTests.swift in Sources */,
 				EDD8F5071F5402040000D3BB /* Link.swift in Sources */,
+				AE1A2B922684BE4E00904D31 /* BatchSyncTests.swift in Sources */,
 				6D87844124FD026F003E69CD /* RelationshipManagerTests.swift in Sources */,
 				EDD8F5021F5402040000D3BB /* SingleRecord+CoreDataProperties.swift in Sources */,
 				EDD8F5161F5402200000D3BB /* Asset+CoreDataProperties.swift in Sources */,
@@ -1367,6 +1390,7 @@
 				6FCA36BD22C65731004F9A5E /* RecordWithNonOptionalRelation.swift in Sources */,
 				6F388F5622E73EC50080585F /* RichTextDocumentTransformableTests.swift in Sources */,
 				EDD8F50F1F5402040000D3BB /* Link.swift in Sources */,
+				AE1A2B932684BE4E00904D31 /* BatchSyncTests.swift in Sources */,
 				6D87844224FD026F003E69CD /* RelationshipManagerTests.swift in Sources */,
 				EDD8F50A1F5402040000D3BB /* SingleRecord+CoreDataProperties.swift in Sources */,
 				EDD8F5201F5402200000D3BB /* Asset+CoreDataProperties.swift in Sources */,

--- a/Tests/ContentfulPersistenceTests/BatchSyncTests.swift
+++ b/Tests/ContentfulPersistenceTests/BatchSyncTests.swift
@@ -1,0 +1,98 @@
+//
+//  BatchSyncTests.swift
+//  ContentfulPersistence
+//
+//  Created by Valerii Andrusyk on 22.06.21.
+//  Copyright © 2021 Contentful GmbH. All rights reserved.
+//
+
+@testable import ContentfulPersistence
+import Contentful
+import XCTest
+import Foundation
+import CoreData
+import OHHTTPStubs
+import CoreLocation
+
+class BatchSyncTests: XCTestCase {
+
+    var syncManager: SynchronizationManager!
+
+    var client: Client!
+
+    lazy var store: CoreDataStore = {
+        return CoreDataStore(context: self.managedObjectContext)
+    }()
+
+    lazy var managedObjectContext: NSManagedObjectContext = {
+        return TestHelpers.managedObjectContext(forMOMInTestBundleNamed: "ComplexTest")
+    }()
+
+    // Before each test.
+    override func setUp() {
+        HTTPStubs.removeAllStubs()
+
+        let persistenceModel = PersistenceModel(spaceType: ComplexSyncInfo.self, assetType: ComplexAsset.self, entryTypes: [SingleRecord.self, Link.self, RecordWithNonOptionalRelation.self])
+
+
+        client = Client(spaceId: "smf0sqiu0c5s",
+                        accessToken: "14d305ad526d4487e21a99b5b9313a8877ce6fbf540f02b12189eea61550ef34")
+        self.syncManager = SynchronizationManager(client: client,
+                                                  localizationScheme: .default,
+                                                  persistenceStore: self.store,
+                                                  persistenceModel: persistenceModel)
+    }
+
+    // After each test.
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+    }
+
+    func testBatchUpdating() {
+
+        let expectation = self.expectation(description: "testBatchUpdating")
+
+        stub(condition: isPath("/spaces/smf0sqiu0c5s/environments/master/sync")) { request -> HTTPStubsResponse in
+            let urlString = request.url!.absoluteString
+            let queryItems = URLComponents(string: urlString)!.queryItems!
+            for queryItem in queryItems {
+                if queryItem.name == "initial" {
+                    let stubPath = OHPathForFile("batch-update-initial-sync.json", ComplexSyncTests.self)
+                    return fixture(filePath: stubPath!, headers: ["Content-Type": "application/json"])
+                } else if queryItem.name == "sync_token" && queryItem.value == "wonDrcKnRgcSOF4-wrDCgcKefWzCgsOxwrfCq8KOfMOdXUPCvEnChwEEO8KFwqHDj8KIKHJYwr0Mw4wKw7UAVcOWYsOtw4nCvTUvDn0pw4gBRMKrGyVxIsOcQMKrwpfDhcOZwq3CkzDDvcKsJ8Oew58fJAQLwr3Cv2MGw4h6LcK_w4whQ8KMwr3ClMOhw5zDjMOswqAyw7XDpXDDsiXCvsKfw7JcwqjDucKmKMODwpDDlyvCrCnCjsOww43ClMKUwq8Xw75pXA" {
+                    let stubPath = OHPathForFile("batch-update-initial-sync-page2.json", ComplexSyncTests.self)
+                    return fixture(filePath: stubPath!, headers: ["Content-Type": "application/json"])
+                }
+            }
+            let stubPath = OHPathForFile("simple-update-initial-sync.json", ComplexSyncTests.self)
+            return fixture(filePath: stubPath!, headers: ["Content-Type": "application/json"])
+        }.name = "Initial sync stub"
+
+        client.sync() { result in
+            switch result {
+            case .success(let space):
+                // There are only SingleRecords, Links and ComplexAssets in stub files
+                // All should be saved to CoreData
+                self.managedObjectContext.perform {
+                    do {
+                        let records: [SingleRecord] = try self.store.fetchAll(type: SingleRecord.self,  predicate: NSPredicate(value: true))
+                        let links: [Link] = try self.store.fetchAll(type: Link.self,  predicate: NSPredicate(value: true))
+                        XCTAssertEqual(records.count + links.count, space.entries.count)
+                        let assets: [ComplexAsset] = try self.store.fetchAll(type: ComplexAsset.self, predicate: NSPredicate(value: true))
+                        XCTAssertEqual(assets.count, space.assets.count)
+                    } catch {
+                        XCTAssert(false, "Fetching posts should not throw an error")
+                    }
+                    expectation.fulfill()
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+                expectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 10.0, handler: nil)
+        HTTPStubs.removeAllStubs()
+    }
+
+}

--- a/Tests/ContentfulPersistenceTests/ComplexTestStubs/batch-update-initial-sync-page2.json
+++ b/Tests/ContentfulPersistenceTests/ComplexTestStubs/batch-update-initial-sync-page2.json
@@ -1,0 +1,222 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "items": [
+      {
+        "sys": {
+          "space": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Space",
+              "id": "smf0sqiu0c5s"
+            }
+          },
+          "id": "7vervB1KtUYWC22OCcmsKc1",
+          "type": "Entry",
+          "createdAt": "2017-06-20T12:51:06.955Z",
+          "updatedAt": "2017-06-20T12:51:06.955Z",
+          "revision": 1,
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "link"
+            }
+          }
+        },
+        "fields": {
+          "awesomeLinkTitle": {
+            "en-US": "Awesome"
+          }
+        }
+      },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "7vervB1KtUYWC22OCcmsKc",
+        "type": "Entry",
+        "createdAt": "2017-06-20T12:51:06.955Z",
+        "updatedAt": "2017-06-20T12:51:06.955Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "3"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "NNPT58qeyYKauym8S0MUk",
+        "type": "Entry",
+        "createdAt": "2017-06-20T12:51:00.210Z",
+        "updatedAt": "2017-06-20T12:51:00.210Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "2"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3PbLvOJldSc6MqKEaIE6Ce",
+        "type": "Entry",
+        "createdAt": "2017-06-20T12:50:15.724Z",
+        "updatedAt": "2017-06-20T12:50:15.724Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "1"
+        }
+      }
+    },
+    {
+        "sys": {
+            "space": {
+                "sys": {
+                    "type": "Link",
+                    "linkType": "Space",
+                    "id": "smf0sqiu0c5s"
+                }
+            },
+            "id": "YokO2rWbOoo68QmiEUkqe",
+            "type": "Asset",
+            "createdAt": "2018-04-02T08:13:10.692Z",
+            "updatedAt": "2018-04-02T08:13:10.692Z",
+            "revision": 1
+        },
+        "fields": {
+            "title": {
+                "en-US": "Video asset"
+            },
+            "description": {
+                "en-US": "this is a video"
+            },
+            "file": {
+                "en-US": {
+                    "url": "//videos.ctfassets.net/smf0sqiu0c5s/YokO2rWbOoo68QmiEUkqe/5cd5ab8fc90e7b9b4d99d56ea29de768/JP_Swift_Demo.mp4",
+                    "details": {
+                        "size": 12429451
+                    },
+                    "fileName": "JP_Swift_Demo.mp4",
+                    "contentType": "video/mp4"
+                }
+            }
+        }
+    },
+    {
+        "sys": {
+            "space": {
+                "sys": {
+                    "type": "Link",
+                    "linkType": "Space",
+                    "id": "smf0sqiu0c5s"
+                }
+            },
+            "id": "YokO2rWbOoo68QmiEUkqe1",
+            "type": "Asset",
+            "createdAt": "2018-04-02T08:13:10.692Z",
+            "updatedAt": "2018-04-02T08:13:10.692Z",
+            "revision": 1
+        },
+        "fields": {
+            "title": {
+                "en-US": "Video asset 1"
+            },
+            "description": {
+                "en-US": "this is a video"
+            },
+            "file": {
+                "en-US": {
+                    "url": "//videos.ctfassets.net/smf0sqiu0c5s/YokO2rWbOoo68QmiEUkqe/5cd5ab8fc90e7b9b4d99d56ea29de768/JP_Swift_Demo.mp4",
+                    "details": {
+                        "size": 12429451
+                    },
+                    "fileName": "JP_Swift_Demo.mp4",
+                    "contentType": "video/mp4"
+                }
+            }
+        }
+    },
+    {
+        "sys": {
+            "space": {
+                "sys": {
+                    "type": "Link",
+                    "linkType": "Space",
+                    "id": "smf0sqiu0c5s"
+                }
+            },
+            "id": "YokO2rWbOoo68QmiEUkqe2",
+            "type": "Asset",
+            "createdAt": "2018-04-02T08:13:10.692Z",
+            "updatedAt": "2018-04-02T08:13:10.692Z",
+            "revision": 1
+        },
+        "fields": {
+            "title": {
+                "en-US": "Video asset 2"
+            },
+            "description": {
+                "en-US": "this is a video"
+            },
+            "file": {
+                "en-US": {
+                    "url": "//videos.ctfassets.net/smf0sqiu0c5s/YokO2rWbOoo68QmiEUkqe/5cd5ab8fc90e7b9b4d99d56ea29de768/JP_Swift_Demo.mp4",
+                    "details": {
+                        "size": 12429451
+                    },
+                    "fileName": "JP_Swift_Demo.mp4",
+                    "contentType": "video/mp4"
+                }
+            }
+        }
+    }
+  ],
+  "nextSyncUrl": "https://cdn.contentful.com/spaces/smf0sqiu0c5s/environments/master/sync?sync_token=w5ZGw6JFwqZmVcKsE8Kow4grw45QdyYxPMK6EcOWw7swwqJhAcOTwqwMwoLCkUFqwpkGMHnDicOeCls-wpHCtSHDiMOJwp9Zw6URwqHCqcK4fFNpDV12wpzDpcKAw71Uw53Dk8KdwrYDw7DCqQU1w4bCg8KkwojDhsOb"
+}

--- a/Tests/ContentfulPersistenceTests/ComplexTestStubs/batch-update-initial-sync.json
+++ b/Tests/ContentfulPersistenceTests/ComplexTestStubs/batch-update-initial-sync.json
@@ -1,0 +1,2808 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "items": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "aNt2d7YR4AIwEAMcG4OwI",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:28.985Z",
+        "updatedAt": "2017-07-13T09:49:17.125Z",
+        "revision": 3,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "Hello"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "14XouHzspI44uKCcMicWUY",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:29.046Z",
+        "updatedAt": "2017-06-22T09:09:16.166Z",
+        "revision": 2,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "12"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "5GiLOZvY7SiMeUIgIIAssS",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:29.319Z",
+        "updatedAt": "2017-06-20T14:03:29.319Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "15"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1N7rfyWDCQGoiQk204aWAS",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:29.282Z",
+        "updatedAt": "2017-06-20T14:03:29.282Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "11"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "iIjks5ZkbY6KyICk28I8A",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:28.997Z",
+        "updatedAt": "2017-06-20T14:03:28.997Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "13"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "yulOlzRnPwES6k6wCQEEQ",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:28.978Z",
+        "updatedAt": "2017-06-20T14:03:28.978Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "14"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "57e6FQmZRYGGmqUA4kQQuC",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:28.938Z",
+        "updatedAt": "2017-06-20T14:03:28.938Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "16"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1zG8vYE66QYKuaeoMUcgg2",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:28.417Z",
+        "updatedAt": "2017-06-20T14:03:28.417Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "18"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "M3WkI23femMgM6s2maqcG",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:28.052Z",
+        "updatedAt": "2017-06-20T14:03:28.052Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "23"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1oTl4pptic6EIgY4uoycWM",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:27.982Z",
+        "updatedAt": "2017-06-20T14:03:27.982Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "20"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4lGFNkVAJaMgMwaMk8CgOI",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:27.981Z",
+        "updatedAt": "2017-06-20T14:03:27.981Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "24"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3UNm47p8BiASIIe8IcYAOk",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:27.971Z",
+        "updatedAt": "2017-06-20T14:03:27.971Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "19"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4b0nwRq01qEk8KGGWwqICo",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:27.945Z",
+        "updatedAt": "2017-06-20T14:03:27.945Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "22"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3uqz3oYIuAMO88MGAG0Asq",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:19.945Z",
+        "updatedAt": "2017-06-20T14:03:19.945Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "25"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3lqALBzrNSI68Ak4wM0sYS",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:19.896Z",
+        "updatedAt": "2017-06-20T14:03:19.896Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "26"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "7zApSMPy7YMuA6YCmsUeYC",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:19.843Z",
+        "updatedAt": "2017-06-20T14:03:19.843Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "28"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "6VhWUsyueQcKgo2eIqCqca",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:19.843Z",
+        "updatedAt": "2017-06-20T14:03:19.843Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "27"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3ejAyhUSYg0cY8s6UwwgY0",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:19.787Z",
+        "updatedAt": "2017-06-20T14:03:19.787Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "29"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "6OW0ArlP44kIeGIyYwmkQW",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:19.442Z",
+        "updatedAt": "2017-06-20T14:03:19.442Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "30"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "pH1nj6skbAAsc6ky4UcGE",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:19.229Z",
+        "updatedAt": "2017-06-20T14:03:19.229Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "31"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "5KfZmQCSD6QwuSUYoiGEMQ",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.957Z",
+        "updatedAt": "2017-06-20T14:03:18.957Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "32"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3Hs3MvyzFC40C2S4uIqwSc",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.906Z",
+        "updatedAt": "2017-06-20T14:03:18.906Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "35"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4NllUc2U9Ga6uuAQA6cEO6",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.899Z",
+        "updatedAt": "2017-06-20T14:03:18.899Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "34"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "50Gma8v16EmiskgK8Uaqo2",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.865Z",
+        "updatedAt": "2017-06-20T14:03:18.865Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "37"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "17dKh00EM6acEKo60YMiec",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.855Z",
+        "updatedAt": "2017-06-20T14:03:18.855Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "33"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3gcaVhENDiSyWQeC8kCuWW",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.834Z",
+        "updatedAt": "2017-06-20T14:03:18.834Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "36"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "6jFhEGCHw4aiqQIQmEymco",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.407Z",
+        "updatedAt": "2017-06-20T14:03:18.407Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "43"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3yQj8wQUFaKUUa4Q2sG2QW",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.284Z",
+        "updatedAt": "2017-06-20T14:03:18.284Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "38"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3XwJJBFfgkIycWuWOW42IU",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.276Z",
+        "updatedAt": "2017-06-20T14:03:18.276Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "41"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "2jSuQXC6Ww4eQWE0ag2QkA",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.260Z",
+        "updatedAt": "2017-06-20T14:03:18.260Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "39"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "69bskCyDmMCGC2qqOYYkSm",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.255Z",
+        "updatedAt": "2017-06-20T14:03:18.255Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "40"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4OjtAnfZMIKQQuOsMkokkS",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:18.242Z",
+        "updatedAt": "2017-06-20T14:03:18.242Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "42"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "ffgHMaZ8rYwuOiUq2sqWm",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:17.044Z",
+        "updatedAt": "2017-06-20T14:03:17.044Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "44"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "7vM1XwDDBmA4gWe2WyGUiw",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:16.676Z",
+        "updatedAt": "2017-06-20T14:03:16.676Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "45"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1CmNKXX5ROC4ygqMk0EI2W",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:16.397Z",
+        "updatedAt": "2017-06-20T14:03:16.397Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "47"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4rNYpb6nvGemaMaIm4wcqI",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:16.346Z",
+        "updatedAt": "2017-06-20T14:03:16.346Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "46"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "5IBg7NDBrGWCK4W4uI6KUs",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:16.343Z",
+        "updatedAt": "2017-06-20T14:03:16.343Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "48"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1qSpUcTSAkmEgGCkWymUuK",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:16.339Z",
+        "updatedAt": "2017-06-20T14:03:16.339Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "50"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3rJI7YxHUIWUgwEEOAEYmq",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:16.331Z",
+        "updatedAt": "2017-06-20T14:03:16.331Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "49"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1twFMD8lfSUyAUQGyYOC4W",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:15.696Z",
+        "updatedAt": "2017-06-20T14:03:15.696Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "51"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1awhhBoxzm8oM4GOEmYMeU",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:15.445Z",
+        "updatedAt": "2017-06-20T14:03:15.445Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "52"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "5DuKsYvRoAoamKik0WIoaO",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:15.375Z",
+        "updatedAt": "2017-06-20T14:03:15.375Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "55"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "pi8YMyI7GSegkqm6yAYqU",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:15.369Z",
+        "updatedAt": "2017-06-20T14:03:15.369Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "54"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "7MrQSRYbmMe2YA6okOUgi6",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:15.365Z",
+        "updatedAt": "2017-06-20T14:03:15.365Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "56"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "6pZDeZPUzuii4w4iEki4UI",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:15.358Z",
+        "updatedAt": "2017-06-20T14:03:15.358Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "57"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3b4HLvrtkICScSIMqWIOWM",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:15.344Z",
+        "updatedAt": "2017-06-20T14:03:15.344Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "53"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1KTzO7eVhiEEk08KWGCM08",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:14.945Z",
+        "updatedAt": "2017-06-20T14:03:14.945Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "58"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3TgCRCqsIMGS2Y80kkwua0",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:14.680Z",
+        "updatedAt": "2017-06-20T14:03:14.680Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "62"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "6san0bCiM8yMq42yMoQ2UA",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:14.586Z",
+        "updatedAt": "2017-06-20T14:03:14.586Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "61"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1pDBbFO1wcyoYY6i4AM0Kw",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:14.574Z",
+        "updatedAt": "2017-06-20T14:03:14.574Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "60"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4T531CEEKs2QCiSY2mi8uQ",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:14.564Z",
+        "updatedAt": "2017-06-20T14:03:14.564Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "63"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "5Oz4MZoC5iCeEO6qiYeCCK",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:14.561Z",
+        "updatedAt": "2017-06-20T14:03:14.561Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "64"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "6BPIuWcMBGYs2u4SaOesM0",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:03:14.551Z",
+        "updatedAt": "2017-06-20T14:03:14.551Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "59"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "2KZpKgWTdCQsa2kgAEIGyK",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:26.421Z",
+        "updatedAt": "2017-06-20T14:02:26.421Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "65"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3tmWlKpwnm2A6qg8swGkCQ",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:26.344Z",
+        "updatedAt": "2017-06-20T14:02:26.344Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "66"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1JpaPruIu0AAcIUkocu2M0",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:26.272Z",
+        "updatedAt": "2017-06-20T14:02:26.272Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "67"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4f9oe0xrLGq4CCQUOGImwI",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:26.139Z",
+        "updatedAt": "2017-06-20T14:02:26.139Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "69"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4FrsNcKjNmuiCeCAccKScs",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:26.131Z",
+        "updatedAt": "2017-06-20T14:02:26.131Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "68"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "6O9ee1FCBGcSYE2SoyCGUO",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:25.952Z",
+        "updatedAt": "2017-06-20T14:02:25.952Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "70"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3WT93x0kggqkqOwAqcoIka",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:25.743Z",
+        "updatedAt": "2017-06-20T14:02:25.743Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "72"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1H1LQwcJruWUKg48G6IMyw",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:25.458Z",
+        "updatedAt": "2017-06-20T14:02:25.458Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "71"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "2EV8LHP3AIiIywGAwqqW04",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:25.342Z",
+        "updatedAt": "2017-06-20T14:02:25.342Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "73"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "6Wrpc6GIKIACmKiQsEKCkg",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:25.203Z",
+        "updatedAt": "2017-06-20T14:02:25.203Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "74"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "2G3TZg4hkIkEGKqAeE0gGm",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:25.116Z",
+        "updatedAt": "2017-06-20T14:02:25.116Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "75"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "7qSan6P6pOcOc48KgiOIkm",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:25.095Z",
+        "updatedAt": "2017-06-20T14:02:25.095Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "76"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "5eRyPQQEJOK68m6kS4o0im",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:24.964Z",
+        "updatedAt": "2017-06-20T14:02:24.964Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "77"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "6uq4n9Ha5UGSy6SIiEmOyQ",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:24.457Z",
+        "updatedAt": "2017-06-20T14:02:24.457Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "78"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4Y5SIQHnBuIWCqAeuCCSYM",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:24.431Z",
+        "updatedAt": "2017-06-20T14:02:24.431Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "80"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "38itCd5zVKqKqeGg2Eaa4m",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:24.428Z",
+        "updatedAt": "2017-06-20T14:02:24.428Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "79"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "5zPE0R3tJe2CgWOYaYug28",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:24.208Z",
+        "updatedAt": "2017-06-20T14:02:24.208Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "81"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "5jlPnbzP0sYoI2kc8My6Ew",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:24.165Z",
+        "updatedAt": "2017-06-20T14:02:24.165Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "83"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "JSbQjAX2msw0mWAAUIsY8",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:24.162Z",
+        "updatedAt": "2017-06-20T14:02:24.162Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "82"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "32hRyKpmXYOIwYE28wcmOK",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:23.947Z",
+        "updatedAt": "2017-06-20T14:02:23.947Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "84"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "2H4ALffX7GYa8wywAmgsoQ",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:23.626Z",
+        "updatedAt": "2017-06-20T14:02:23.626Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "86"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "M5QqYxwC2qucocEGys8es",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:23.589Z",
+        "updatedAt": "2017-06-20T14:02:23.589Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "85"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4pWQrOzLc4AgiKiYUwIqIO",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:23.552Z",
+        "updatedAt": "2017-06-20T14:02:23.552Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "87"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3NS51Q6VfWuSAeyGwWsskG",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:23.450Z",
+        "updatedAt": "2017-06-20T14:02:23.450Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "91"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "5XN7jqvcC4K0skso0a8cm4",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:23.184Z",
+        "updatedAt": "2017-06-20T14:02:23.184Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "88"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "7h7SLcnjd6acQe0aAK0Asq",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:23.156Z",
+        "updatedAt": "2017-06-20T14:02:23.156Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "89"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1z8AWFb76o2SGSGaEqoUyU",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:23.094Z",
+        "updatedAt": "2017-06-20T14:02:23.094Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "90"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4t8qPhl28goI42OYqyOG6g",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:22.558Z",
+        "updatedAt": "2017-06-20T14:02:22.558Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "92"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "552hMBBQLCWKS4WSKAa4mQ",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:22.453Z",
+        "updatedAt": "2017-06-20T14:02:22.453Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "93"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1suHNrRW3q6UuQuI0IseuU",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:22.429Z",
+        "updatedAt": "2017-06-20T14:02:22.429Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "94"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "8ssm0fZnk4Wo6yK6YWgsC",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:22.320Z",
+        "updatedAt": "2017-06-20T14:02:22.320Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "95"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "2G9X8f658sUc0AiusIu2AK",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:22.231Z",
+        "updatedAt": "2017-06-20T14:02:22.231Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "97"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3zQh9hvB7ioAgIK200C6gE",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:22.208Z",
+        "updatedAt": "2017-06-20T14:02:22.208Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "96"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "2uBFSNVkniWeQwAomgSWI0",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:22.011Z",
+        "updatedAt": "2017-06-20T14:02:22.011Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "98"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1PR2BZYKuseeEU044CMyW6",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:21.947Z",
+        "updatedAt": "2017-06-20T14:02:21.947Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "103"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "2XPs0uB6Za2CgU00sAI6KS",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:21.935Z",
+        "updatedAt": "2017-06-20T14:02:21.935Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "101"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "45Xpt3gRpeWS0WW4SoEYaW",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:21.903Z",
+        "updatedAt": "2017-06-20T14:02:21.903Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "100"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3EZVUIJxSocEqsaQwW60c0",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:21.678Z",
+        "updatedAt": "2017-06-20T14:02:21.678Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "99"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "m9rgbslEmk2AuY64kEi8A",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:21.651Z",
+        "updatedAt": "2017-06-20T14:02:21.651Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "102"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "1o71Ny0Yuc0oG0iEI4igmg",
+        "type": "Entry",
+        "createdAt": "2017-06-20T14:02:21.642Z",
+        "updatedAt": "2017-06-20T14:02:21.642Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "104"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "4vWm9jjqCAGimQ4sSkqayk",
+        "type": "Entry",
+        "createdAt": "2017-06-20T12:54:26.953Z",
+        "updatedAt": "2017-06-20T12:54:26.953Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "7"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "54WtT4aKOs4MWaoEMKm2Yu",
+        "type": "Entry",
+        "createdAt": "2017-06-20T12:54:20.521Z",
+        "updatedAt": "2017-06-20T12:54:20.521Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "9"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "3JR4lwrMnK8EME8scaau2k",
+        "type": "Entry",
+        "createdAt": "2017-06-20T12:51:56.964Z",
+        "updatedAt": "2017-06-20T12:51:56.964Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "10"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "5TQUKNLr2wYcyOoEM6SE8A",
+        "type": "Entry",
+        "createdAt": "2017-06-20T12:51:38.399Z",
+        "updatedAt": "2017-06-20T12:51:38.399Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "8"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "7d3vN5f6fusy0gocQuUCK0",
+        "type": "Entry",
+        "createdAt": "2017-06-20T12:51:29.371Z",
+        "updatedAt": "2017-06-20T12:51:29.371Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "6"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "6Dxnt0zVJYkewU8YWsC6UY",
+        "type": "Entry",
+        "createdAt": "2017-06-20T12:51:19.104Z",
+        "updatedAt": "2017-06-20T12:51:19.104Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "5"
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "smf0sqiu0c5s"
+          }
+        },
+        "id": "2eXtYKYxYAue2IQgaucoYW",
+        "type": "Entry",
+        "createdAt": "2017-06-20T12:51:13.910Z",
+        "updatedAt": "2017-06-20T12:51:13.910Z",
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "singleRecord"
+          }
+        }
+      },
+      "fields": {
+        "textBody": {
+          "en-US": "4"
+        }
+      }
+    }
+  ],
+  "nextPageUrl": "https://cdn.contentful.com/spaces/smf0sqiu0c5s/environments/master/sync?sync_token=wonDrcKnRgcSOF4-wrDCgcKefWzCgsOxwrfCq8KOfMOdXUPCvEnChwEEO8KFwqHDj8KIKHJYwr0Mw4wKw7UAVcOWYsOtw4nCvTUvDn0pw4gBRMKrGyVxIsOcQMKrwpfDhcOZwq3CkzDDvcKsJ8Oew58fJAQLwr3Cv2MGw4h6LcK_w4whQ8KMwr3ClMOhw5zDjMOswqAyw7XDpXDDsiXCvsKfw7JcwqjDucKmKMODwpDDlyvCrCnCjsOww43ClMKUwq8Xw75pXA"
+}


### PR DESCRIPTION
Function `update(with syncSpace: SyncSpace)` is processing each asset/entry one by one, and this cause to many CoreData fetches in case of many changes in Contentful since previous app launch.
Suggested improvements are fetching with IN predicate, which leads to decreasing count of fetches and speeding up the update process.
