### PR TITLE
Fix issue where for field of primitive list, field name and property name should be same, else crash occurs

### DIFF
--- a/Sources/ContentfulPersistence/SynchronizationManager.swift
+++ b/Sources/ContentfulPersistence/SynchronizationManager.swift
@@ -591,7 +591,7 @@ public class SynchronizationManager: PersistenceIntegration {
         for (fieldName, propertyName) in mapping {
             var fieldValue = entry.fields[fieldName]
 
-            let attributeType = persistable.entity.attributesByName[fieldName]?.attributeType
+            let attributeType = persistable.entity.attributesByName[propertyName]?.attributeType
             // handle symbol arrays as NSData if field is of type .binaryDataAttributeType, otherwise use .transformableAttributeType
             if attributeType == .binaryDataAttributeType, let array = fieldValue as? [NSCoding] {
                 fieldValue = NSKeyedArchiver.archivedData(withRootObject: array)


### PR DESCRIPTION
Fix issue where field name is used for fetching property type instead of property name, resulting in crash when field name is "FieldName" and property name is "fieldname", since it wont get the property type as data