### PR TITLE
fix watchOS target support

### DIFF
--- a/Sources/ContentfulPersistence/CoreDataStore.swift
+++ b/Sources/ContentfulPersistence/CoreDataStore.swift
@@ -165,7 +165,7 @@ public class CoreDataStore: PersistenceStore {
         
         // Reset the store at the same location with the same options.
         // TODO: let user pass-in configurations if needed. For now assumed its nil.
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOSApplicationExtension 8.0, *) {
+        if #available(watchOSApplicationExtension 8.0, iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8, *) {
             let storeTypeObject = NSPersistentStore.StoreType(rawValue: storeType)
             try coordinator.destroyPersistentStore(at: storeLocation, type: storeTypeObject, options: storeOptions)
             try _ = coordinator.addPersistentStore(type: storeTypeObject, configuration: nil, at: storeLocation, options: storeOptions)


### PR DESCRIPTION
There's an issue in the package currently which prevents us from using this inside a watchOS target. 
Fixed it by setting the #if available check correctly for watchOS 8.0